### PR TITLE
CRYP-51: Fix sign in page styling to match UI mockups

### DIFF
--- a/packages/client/App.tsx
+++ b/packages/client/App.tsx
@@ -6,16 +6,18 @@ import useColorScheme from "./hooks/useColorScheme";
 import Navigation from "./navigation";
 import { NativeBaseProvider } from "native-base";
 import React from "react";
+import extendTheme from "./theme/extendTheme";
 
 export default function App() {
     const isLoadingComplete = useCachedResources();
     const colorScheme = useColorScheme();
+    const theme = extendTheme();
 
     if (!isLoadingComplete) {
         return null;
     } else {
         return (
-            <NativeBaseProvider>
+            <NativeBaseProvider theme={theme}>
                 <SafeAreaProvider>
                     <Navigation colorScheme={colorScheme} />
                     <StatusBar />

--- a/packages/client/screens/SignInScreen.tsx
+++ b/packages/client/screens/SignInScreen.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { Input, Button, VStack, FormControl, Pressable } from "native-base";
-import { Text, View } from "../components/Themed";
+import { Input, Button, VStack, FormControl, Pressable, Text } from "native-base";
+import { View } from "../components/Themed";
 import { Formik } from "formik";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { faEyeCustom } from "../components/icons/faEyeCustom";
@@ -40,15 +40,12 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
             <Text style={styles.title}>Welcome back</Text>
             <Formik initialValues={initialValues} validationSchema={signInSchema} onSubmit={onSubmitSignIn}>
                 {({ values, errors, touched, handleChange, submitForm }) => (
-                    <VStack space={3} style={{ marginHorizontal: 20, marginTop: 35 }}>
+                    <VStack space="13" style={{ marginHorizontal: 20, marginTop: 35 }}>
                         <FormControl isInvalid={!!(errors.email && touched.email)}>
                             <Input
                                 value={values.email}
                                 onChangeText={handleChange("email")}
                                 placeholder="Email"
-                                style={errors.email && touched.email ? styles.formError : null}
-                                borderRadius="10"
-                                height="46"
                             />
                             <FormControl.ErrorMessage>{errors.email}</FormControl.ErrorMessage>
                         </FormControl>
@@ -65,22 +62,11 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
                                     </Pressable>
                                 }
                                 onChangeText={handleChange("password")}
-                                placeholder="Password (6+ characters)"
-                                style={errors.password && touched.password ? styles.formError : null}
-                                borderRadius="10"
-                                height="46"
+                                placeholder="Password"
                             />
-
                             <FormControl.ErrorMessage>{errors.password}</FormControl.ErrorMessage>
                         </FormControl>
-                        <Button
-                            style={styles.formButton}
-                            onPress={submitForm}
-                            mt={2}
-                            _text={{ fontWeight: 600, fontSize: 16 }}
-                        >
-                            Sign in
-                        </Button>
+                        <Button style={{ marginTop: 7 }} onPress={submitForm}>Sign in</Button>
                     </VStack>
                 )}
             </Formik>
@@ -94,20 +80,10 @@ const styles = StyleSheet.create({
         fontWeight: "bold",
         textAlign: "center",
     },
-    formButton: {
-        height: 44,
-        borderRadius: 100,
-        backgroundColor: "#0077E6",
-    },
-    formError: {
-        backgroundColor: "#FFE4E6",
-        borderWidth: 0.5,
-        borderColor: "#DC2626",
-    },
     eyeIcon: {
         color: "#404040",
-        width: 20,
-        height: 16,
+        width: 23,
+        height: 18,
         marginRight: 12,
     },
 });

--- a/packages/client/screens/SignInScreen.tsx
+++ b/packages/client/screens/SignInScreen.tsx
@@ -42,11 +42,7 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
                 {({ values, errors, touched, handleChange, submitForm }) => (
                     <VStack space="13" style={{ marginHorizontal: 20, marginTop: 35 }}>
                         <FormControl isInvalid={!!(errors.email && touched.email)}>
-                            <Input
-                                value={values.email}
-                                onChangeText={handleChange("email")}
-                                placeholder="Email"
-                            />
+                            <Input value={values.email} onChangeText={handleChange("email")} placeholder="Email" />
                             <FormControl.ErrorMessage>{errors.email}</FormControl.ErrorMessage>
                         </FormControl>
                         <FormControl isInvalid={!!(errors.password && touched.password)}>
@@ -66,7 +62,9 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
                             />
                             <FormControl.ErrorMessage>{errors.password}</FormControl.ErrorMessage>
                         </FormControl>
-                        <Button style={{ marginTop: 7 }} onPress={submitForm}>Sign in</Button>
+                        <Button style={{ marginTop: 7 }} onPress={submitForm}>
+                            Sign in
+                        </Button>
                     </VStack>
                 )}
             </Formik>

--- a/packages/client/theme/components/button.ts
+++ b/packages/client/theme/components/button.ts
@@ -1,0 +1,32 @@
+export const button = {
+    baseStyle: {
+        borderRadius: '100',
+        height: '50',
+        _text: {
+            fontWeight: 'semibold',
+        },
+        _loading: {
+            opacity: '60',
+        },
+    },
+    variants: {
+        solid: {
+            bg: 'darkBlue.500',
+            _text: {
+                color: 'white',
+            },
+            _hover: {
+                bg: 'darkBlue.500',
+                opacity: '60',
+            },
+            _pressed: {
+                bg: 'darkBlue.500',
+                opacity: '60',
+            },
+        },
+    },
+    defaultProps: {
+        variant: 'solid',
+        size: 'lg',
+    },
+};

--- a/packages/client/theme/components/button.ts
+++ b/packages/client/theme/components/button.ts
@@ -1,32 +1,32 @@
 export const button = {
     baseStyle: {
-        borderRadius: '100',
-        height: '50',
+        borderRadius: "100",
+        height: "50",
         _text: {
-            fontWeight: 'semibold',
+            fontWeight: "semibold",
         },
         _loading: {
-            opacity: '60',
+            opacity: "60",
         },
     },
     variants: {
         solid: {
-            bg: 'darkBlue.500',
+            bg: "darkBlue.500",
             _text: {
-                color: 'white',
+                color: "white",
             },
             _hover: {
-                bg: 'darkBlue.500',
-                opacity: '60',
+                bg: "darkBlue.500",
+                opacity: "60",
             },
             _pressed: {
-                bg: 'darkBlue.500',
-                opacity: '60',
+                bg: "darkBlue.500",
+                opacity: "60",
             },
         },
     },
     defaultProps: {
-        variant: 'solid',
-        size: 'lg',
+        variant: "solid",
+        size: "lg",
     },
 };

--- a/packages/client/theme/components/form-control.ts
+++ b/packages/client/theme/components/form-control.ts
@@ -1,8 +1,8 @@
 export const formControlErrorMessage = {
     baseStyle: {
-        marginTop: '4px',
+        marginTop: "4px",
         _text: {
-            fontSize: '15',
+            fontSize: "15",
         },
     },
-}
+};

--- a/packages/client/theme/components/form-control.ts
+++ b/packages/client/theme/components/form-control.ts
@@ -1,0 +1,8 @@
+export const formControlErrorMessage = {
+    baseStyle: {
+        marginTop: '4px',
+        _text: {
+            fontSize: '15',
+        },
+    },
+}

--- a/packages/client/theme/components/input.ts
+++ b/packages/client/theme/components/input.ts
@@ -1,0 +1,58 @@
+export const input = {
+    baseStyle: {
+        height: '46',
+        borderRadius: '10',
+        placeholderTextColor: 'text.400',
+        borderColor: 'text.300',
+        color: 'text.700',
+
+        _hover: {
+            borderColor: 'darkBlue.500',
+        },
+        _focus: {
+            borderColor: 'darkBlue.500',
+            bg: 'white',
+
+            _hover: {
+                borderColor: 'darkBlue.500',
+            },
+            _invalid: {
+                borderWidth: '1px',
+                borderColor: 'error.600',
+                bg: 'rose.100',
+                placeholderTextColor: 'error.600',
+                _hover: {
+                    borderColor:
+                        'error.600'
+                },
+            },
+            _ios: {
+                selectionColor: 'darkBlue.500',
+            },
+            _android: {
+                selectionColor: 'darkBlue.500',
+            },
+        },
+        _invalid: {
+            borderColor: 'error.600',
+            bg: 'rose.100',
+            placeholderTextColor: 'error.600',
+            _hover: {
+                borderColor: 'error.600',
+                bg: 'rose.100',
+            },
+        },
+    },
+    variants: {
+        outline: {
+            borderWidth: '1px',
+            _focus: {
+                bg: 'white',
+            }
+        }
+    },
+    defaultProps: {
+        size: 'lg',
+        variant: 'outline',
+    },
+}

--- a/packages/client/theme/components/input.ts
+++ b/packages/client/theme/components/input.ts
@@ -1,58 +1,57 @@
 export const input = {
     baseStyle: {
-        height: '46',
-        borderRadius: '10',
-        placeholderTextColor: 'text.400',
-        borderColor: 'text.300',
-        color: 'text.700',
+        height: "46",
+        borderRadius: "10",
+        placeholderTextColor: "text.400",
+        borderColor: "text.300",
+        color: "text.700",
 
         _hover: {
-            borderColor: 'darkBlue.500',
+            borderColor: "darkBlue.500",
         },
         _focus: {
-            borderColor: 'darkBlue.500',
-            bg: 'white',
+            borderColor: "darkBlue.500",
+            bg: "white",
 
             _hover: {
-                borderColor: 'darkBlue.500',
+                borderColor: "darkBlue.500",
             },
             _invalid: {
-                borderWidth: '1px',
-                borderColor: 'error.600',
-                bg: 'rose.100',
-                placeholderTextColor: 'error.600',
+                borderWidth: "1px",
+                borderColor: "error.600",
+                bg: "rose.100",
+                placeholderTextColor: "error.600",
                 _hover: {
-                    borderColor:
-                        'error.600'
+                    borderColor: "error.600",
                 },
             },
             _ios: {
-                selectionColor: 'darkBlue.500',
+                selectionColor: "darkBlue.500",
             },
             _android: {
-                selectionColor: 'darkBlue.500',
+                selectionColor: "darkBlue.500",
             },
         },
         _invalid: {
-            borderColor: 'error.600',
-            bg: 'rose.100',
-            placeholderTextColor: 'error.600',
+            borderColor: "error.600",
+            bg: "rose.100",
+            placeholderTextColor: "error.600",
             _hover: {
-                borderColor: 'error.600',
-                bg: 'rose.100',
+                borderColor: "error.600",
+                bg: "rose.100",
             },
         },
     },
     variants: {
         outline: {
-            borderWidth: '1px',
+            borderWidth: "1px",
             _focus: {
-                bg: 'white',
-            }
-        }
+                bg: "white",
+            },
+        },
     },
     defaultProps: {
-        size: 'lg',
-        variant: 'outline',
+        size: "lg",
+        variant: "outline",
     },
-}
+};

--- a/packages/client/theme/components/text.ts
+++ b/packages/client/theme/components/text.ts
@@ -1,5 +1,5 @@
 export const text = {
     baseStyle: {
-        color: 'text.700',
-    }
-}
+        color: "text.700",
+    },
+};

--- a/packages/client/theme/components/text.ts
+++ b/packages/client/theme/components/text.ts
@@ -1,0 +1,5 @@
+export const text = {
+    baseStyle: {
+        color: 'text.700',
+    }
+}

--- a/packages/client/theme/extendTheme.tsx
+++ b/packages/client/theme/extendTheme.tsx
@@ -1,0 +1,62 @@
+import { extendTheme } from 'native-base';
+import { text } from "./components/text";
+import { button } from "./components/button";
+import { input } from "./components/input";
+import { formControlErrorMessage } from "./components/form-control";
+
+export default function () {
+    return extendTheme({
+        fontConfig: {
+            Roboto: {
+                100: {
+                    normal: "Roboto-Light",
+                    italic: "Roboto-LightItalic",
+                },
+                200: {
+                    normal: "Roboto-Light",
+                    italic: "Roboto-LightItalic",
+                },
+                300: {
+                    normal: "Roboto-Light",
+                    italic: "Roboto-LightItalic",
+                },
+                400: {
+                    normal: "Roboto-Regular",
+                    italic: "Roboto-Italic",
+                },
+                500: {
+                    normal: "Roboto-Medium",
+                },
+                600: {
+                    normal: "Roboto-Medium",
+                    italic: "Roboto-MediumItalic",
+                },
+                700: {
+                    normal: 'Roboto-Bold',
+                },
+                800: {
+                    normal: 'Roboto-Bold',
+                    italic: 'Roboto-BoldItalic',
+                  },
+                900: {
+                    normal: 'Roboto-Bold',
+                    italic: 'Roboto-BoldItalic',
+                },
+            },
+        },
+
+        // Make sure values below matches any of the keys in `fontConfig`
+        fonts: {
+            heading: "Roboto",
+            body: "Roboto",
+            mono: "Roboto",
+        },
+
+        components: {
+            Text: text,
+            Button : button,
+            Input: input,
+            FormControlErrorMessage: formControlErrorMessage,
+        }
+    });
+}

--- a/packages/client/theme/extendTheme.tsx
+++ b/packages/client/theme/extendTheme.tsx
@@ -6,52 +6,6 @@ import { formControlErrorMessage } from "./components/form-control";
 
 export default function () {
     return extendTheme({
-        fontConfig: {
-            Roboto: {
-                100: {
-                    normal: "Roboto-Light",
-                    italic: "Roboto-LightItalic",
-                },
-                200: {
-                    normal: "Roboto-Light",
-                    italic: "Roboto-LightItalic",
-                },
-                300: {
-                    normal: "Roboto-Light",
-                    italic: "Roboto-LightItalic",
-                },
-                400: {
-                    normal: "Roboto-Regular",
-                    italic: "Roboto-Italic",
-                },
-                500: {
-                    normal: "Roboto-Medium",
-                },
-                600: {
-                    normal: "Roboto-Medium",
-                    italic: "Roboto-MediumItalic",
-                },
-                700: {
-                    normal: 'Roboto-Bold',
-                },
-                800: {
-                    normal: 'Roboto-Bold',
-                    italic: 'Roboto-BoldItalic',
-                  },
-                900: {
-                    normal: 'Roboto-Bold',
-                    italic: 'Roboto-BoldItalic',
-                },
-            },
-        },
-
-        // Make sure values below matches any of the keys in `fontConfig`
-        fonts: {
-            heading: "Roboto",
-            body: "Roboto",
-            mono: "Roboto",
-        },
-
         components: {
             Text: text,
             Button : button,

--- a/packages/client/theme/extendTheme.tsx
+++ b/packages/client/theme/extendTheme.tsx
@@ -1,4 +1,4 @@
-import { extendTheme } from 'native-base';
+import { extendTheme } from "native-base";
 import { text } from "./components/text";
 import { button } from "./components/button";
 import { input } from "./components/input";
@@ -8,9 +8,9 @@ export default function () {
     return extendTheme({
         components: {
             Text: text,
-            Button : button,
+            Button: button,
             Input: input,
             FormControlErrorMessage: formControlErrorMessage,
-        }
+        },
     });
 }

--- a/packages/common/src/validations/password_schema.ts
+++ b/packages/common/src/validations/password_schema.ts
@@ -4,8 +4,10 @@ import * as yup from "yup";
 // has a minimum length of 8 characters
 export const passwordSchema = yup
     .string()
+    .min(6)
+    .max(20, "Password must be between 6 and 20 characters")
     .matches(
         new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()?+=_]).{6,20}$"),
-        "Password must be between 6 and 20 characters",
+        "Password must contain at least 1 upper case, 1 lower case letter, 1 number, and 1 special character.",
     )
     .required("Enter a password.");

--- a/packages/common/src/validations/password_schema.ts
+++ b/packages/common/src/validations/password_schema.ts
@@ -5,7 +5,7 @@ import * as yup from "yup";
 export const passwordSchema = yup
     .string()
     .min(6)
-    .max(20, "Password must be between 6 and 20 characters")
+    .max(20, "Password must be between 6 and 20 characters.")
     .matches(
         new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()?+=_]).{6,20}$"),
         "Password must contain at least 1 upper case, 1 lower case letter, 1 number, and 1 special character.",

--- a/packages/common/src/validations/password_schema.ts
+++ b/packages/common/src/validations/password_schema.ts
@@ -4,7 +4,7 @@ import * as yup from "yup";
 // has a minimum length of 8 characters
 export const passwordSchema = yup
     .string()
-    .min(6)
+    .min(6, "Password must be between 6 and 20 characters.")
     .max(20, "Password must be between 6 and 20 characters.")
     .matches(
         new RegExp("^(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z])(?=.*[!@#$%^&*()?+=_]).{6,20}$"),

--- a/packages/common/src/validations/sign_in_schema.ts
+++ b/packages/common/src/validations/sign_in_schema.ts
@@ -3,7 +3,7 @@ import { passwordSchema } from "@cryptify/common/src/validations/password_schema
 
 export const signInSchema = yup
     .object({
-        email: yup.string().email().required(),
+        email: yup.string().email("Enter a valid email.").required("Enter a valid email."),
         password: passwordSchema,
     })
     .required();


### PR DESCRIPTION
- Created custom theme files for each component used to match the UI mockups
- Refactored the sign in page to take into account these new additions

![image](https://user-images.githubusercontent.com/15861967/192126359-5fcac618-12c6-4b58-8df8-e4be45f26f0e.png)
![image](https://user-images.githubusercontent.com/15861967/192126366-1fbc2660-49d9-4ee6-8482-cba22fd14234.png)
