### PR TITLE
CRYP-21: Add API error messages to sign up and sign in

### DIFF
--- a/packages/api/src/authentication/authentication.service.ts
+++ b/packages/api/src/authentication/authentication.service.ts
@@ -6,6 +6,7 @@ import { JwtService } from "@nestjs/jwt";
 import { JwtToken } from "@cryptify/common/src/types/jwt_token";
 import { SignUpRequest } from "@cryptify/common/src/requests/sign_up_request";
 import { SignInRequest } from "@cryptify/common/src/requests/sign_in_request";
+import { ERROR_EMAIL_OR_PASSWORD_INCORRECT } from "@cryptify/common/src/errors/error_messages";
 
 @Injectable()
 export class AuthenticationService {
@@ -21,12 +22,12 @@ export class AuthenticationService {
     async signIn(signInReq: SignInRequest): Promise<JwtToken> {
         const user = await this.usersService.findOne(signInReq.email);
         if (!user) {
-            throw new ForbiddenException();
+            throw new ForbiddenException(ERROR_EMAIL_OR_PASSWORD_INCORRECT);
         }
 
         const isMatch = await bcrypt.compare(signInReq.password, user.password);
         if (!isMatch) {
-            throw new ForbiddenException();
+            throw new ForbiddenException(ERROR_EMAIL_OR_PASSWORD_INCORRECT);
         }
 
         return this.signToken(user);

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { User } from "@cryptify/common/src/entities/user";
 import { Repository } from "typeorm";
 import { SignUpRequest } from "@cryptify/common/src/requests/sign_up_request";
+import { ERROR_EMAIL_IN_USE } from "@cryptify/common/src/errors/error_messages";
 
 @Injectable()
 export class UsersService {
@@ -13,7 +14,7 @@ export class UsersService {
 
     async create(signUpReq: SignUpRequest): Promise<User> {
         if (await this.findOne(signUpReq.email)) {
-            throw new BadRequestException();
+            throw new BadRequestException(ERROR_EMAIL_IN_USE);
         }
 
         const createdUser = this.userRepository.create(signUpReq);

--- a/packages/client/App.tsx
+++ b/packages/client/App.tsx
@@ -1,6 +1,5 @@
 import "@env";
 import { StatusBar } from "expo-status-bar";
-import { SafeAreaProvider } from "react-native-safe-area-context";
 import useCachedResources from "./hooks/useCachedResources";
 import useColorScheme from "./hooks/useColorScheme";
 import Navigation from "./navigation";
@@ -18,10 +17,8 @@ export default function App() {
     } else {
         return (
             <NativeBaseProvider theme={theme}>
-                <SafeAreaProvider>
-                    <Navigation colorScheme={colorScheme} />
-                    <StatusBar />
-                </SafeAreaProvider>
+                <StatusBar />
+                <Navigation colorScheme={colorScheme} />
             </NativeBaseProvider>
         );
     }

--- a/packages/client/gateways/auth_gateway.ts
+++ b/packages/client/gateways/auth_gateway.ts
@@ -1,16 +1,16 @@
 import { SignUpRequest } from "@cryptify/common/src/requests/sign_up_request";
 import { JwtToken } from "@cryptify/common/src/types/jwt_token";
-import { request } from "./request";
+import { Method, request } from "./request";
 import { SignInRequest } from "@cryptify/common/src/requests/sign_in_request";
 
 async function signUp(req: SignUpRequest): Promise<JwtToken> {
     const path = "auth/signup";
-    return request<JwtToken>(path, req);
+    return request<JwtToken>(Method.POST, path, req);
 }
 
 async function signIn(req: SignInRequest): Promise<JwtToken> {
     const path = "auth/signin";
-    return request<JwtToken>(path, req);
+    return request<JwtToken>(Method.POST, path, req);
 }
 
 export default {

--- a/packages/client/gateways/request.ts
+++ b/packages/client/gateways/request.ts
@@ -9,6 +9,11 @@ export async function request<T>(path: string, req: any): Promise<T> {
         },
         body: JSON.stringify(req),
     });
+    const body = await response.json();
 
-    return (await response.json()) as T;
+    if (response.status >= 300) {
+        throw new Error(body.message);
+    }
+
+    return body as T;
 }

--- a/packages/client/gateways/request.ts
+++ b/packages/client/gateways/request.ts
@@ -1,19 +1,27 @@
 const API_URI = `http://${process.env.REACT_APP_API_URL}:${process.env.REACT_APP_API_PORT}`;
 
-export async function request<T>(path: string, req: any): Promise<T> {
+export async function request<T>(method: Method, path: string, body: any): Promise<T> {
     const response = await fetch(`${API_URI}/${path}`, {
-        method: "POST",
+        method: Method[method],
         headers: {
             Accept: "application/json",
             "Content-Type": "application/json",
         },
-        body: JSON.stringify(req),
+        body: JSON.stringify(body),
     });
-    const body = await response.json();
+    const resBody = await response.json();
 
     if (response.status >= 300) {
-        throw new Error(body.message);
+        throw new Error(resBody.message);
     }
 
-    return body as T;
+    return resBody as T;
+}
+
+export enum Method {
+    POST,
+    GET,
+    PUT,
+    PATCH,
+    DELETE,
 }

--- a/packages/client/screens/SignInScreen.tsx
+++ b/packages/client/screens/SignInScreen.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { Input, Button, VStack, FormControl, Pressable, Text } from "native-base";
+import { Input, Button, VStack, FormControl, Pressable, Text, Box } from "native-base";
 import { View } from "../components/Themed";
 import { Formik } from "formik";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
@@ -12,6 +12,8 @@ import { RootTabScreenProps } from "../types";
 import { SignInRequest } from "@cryptify/common/src/requests/sign_in_request";
 import { signInSchema } from "@cryptify/common/src/validations/sign_in_schema";
 import { KEY_JWT } from "../constants/storage_keys";
+import { FormikHelpers } from "formik/dist/types";
+import { ERROR_NOP } from "@cryptify/common/src/errors/error_messages";
 
 export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInScreen">) {
     const [showPassword, setShowPass] = React.useState(false);
@@ -21,7 +23,7 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
         password: "",
     };
 
-    async function onSubmitSignIn(values: SignInRequest): Promise<void> {
+    async function onSubmitSignIn(values: SignInRequest, formikHelpers: FormikHelpers<SignInRequest>): Promise<void> {
         try {
             const token = await AuthGateway.signIn(values);
             StorageService.put(KEY_JWT, token);
@@ -31,19 +33,26 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
                 routes: [{ name: "HomeScreen" }],
             });
         } catch (error) {
-            console.error(error);
+            if (error instanceof Error) {
+                formikHelpers.setFieldError("email", ERROR_NOP);
+                formikHelpers.setFieldError("password", error.message);
+            }
         }
     }
 
     return (
         <View style={{ flex: 1, justifyContent: "center" }}>
-            <Text style={styles.title}>Welcome back</Text>
+            <Box safeArea>
+                <Text style={styles.title}>Welcome back</Text>
+            </Box>
             <Formik initialValues={initialValues} validationSchema={signInSchema} onSubmit={onSubmitSignIn}>
                 {({ values, errors, touched, handleChange, submitForm }) => (
                     <VStack space="13" style={{ marginHorizontal: 20, marginTop: 35 }}>
                         <FormControl isInvalid={!!(errors.email && touched.email)}>
                             <Input value={values.email} onChangeText={handleChange("email")} placeholder="Email" />
-                            <FormControl.ErrorMessage>{errors.email}</FormControl.ErrorMessage>
+                            <FormControl.ErrorMessage>
+                                {errors.email != ERROR_NOP && errors.email}
+                            </FormControl.ErrorMessage>
                         </FormControl>
                         <FormControl isInvalid={!!(errors.password && touched.password)}>
                             <Input
@@ -76,6 +85,7 @@ export default function SignInScreen({ navigation }: RootTabScreenProps<"SignInS
 const styles = StyleSheet.create({
     title: {
         fontSize: 28,
+        lineHeight: 32,
         fontWeight: "bold",
         textAlign: "center",
     },

--- a/packages/client/screens/SignUpScreen.tsx
+++ b/packages/client/screens/SignUpScreen.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { Input, Button, VStack, FormControl, Pressable, HStack, Text } from "native-base";
+import { Input, Button, VStack, FormControl, Pressable, HStack, Text, Box } from "native-base";
 import { View } from "../components/Themed";
 import { Formik } from "formik";
 import { signUpSchema } from "@cryptify/common/src/validations/sign_up_schema";
@@ -12,6 +12,7 @@ import StorageService from "../services/storage_service";
 import { RootTabScreenProps } from "../types";
 import { SignUpRequest } from "@cryptify/common/src/requests/sign_up_request";
 import { KEY_JWT } from "../constants/storage_keys";
+import { FormikHelpers } from "formik/dist/types";
 
 export default function SignUpScreen({ navigation }: RootTabScreenProps<"SignUpScreen">) {
     const [showPassword, setShowPass] = React.useState(false);
@@ -25,7 +26,7 @@ export default function SignUpScreen({ navigation }: RootTabScreenProps<"SignUpS
         confirmPassword: "",
     };
 
-    async function onSubmitSignUp(values: SignUpRequest): Promise<void> {
+    async function onSubmitSignUp(values: SignUpRequest, formikHelpers: FormikHelpers<SignUpRequest>): Promise<void> {
         try {
             const token = await AuthGateway.signUp(values);
             StorageService.put(KEY_JWT, token);
@@ -35,12 +36,16 @@ export default function SignUpScreen({ navigation }: RootTabScreenProps<"SignUpS
                 routes: [{ name: "HomeScreen" }],
             });
         } catch (error) {
-            console.error(error);
+            if (error instanceof Error) {
+                formikHelpers.setFieldError("email", error.message);
+            }
         }
     }
     return (
         <View style={{ flex: 1, justifyContent: "center" }}>
-            <Text style={styles.title}>Create an account</Text>
+            <Box safeArea>
+                <Text style={styles.title}>Create an account</Text>
+            </Box>
             <Formik initialValues={initialValues} validationSchema={signUpSchema} onSubmit={onSubmitSignUp}>
                 {({ values, errors, touched, handleChange, submitForm }) => (
                     <VStack space="13" style={{ marginHorizontal: 20, marginTop: 35 }}>
@@ -120,6 +125,7 @@ export default function SignUpScreen({ navigation }: RootTabScreenProps<"SignUpS
 const styles = StyleSheet.create({
     title: {
         fontSize: 28,
+        lineHeight: 32,
         fontWeight: "bold",
         textAlign: "center",
     },

--- a/packages/common/src/errors/error_messages.ts
+++ b/packages/common/src/errors/error_messages.ts
@@ -1,0 +1,3 @@
+export const ERROR_EMAIL_OR_PASSWORD_INCORRECT = "Your email or password was incorrect.";
+export const ERROR_EMAIL_IN_USE = "This email address is already associated with another account.";
+export const ERROR_NOP = "nop";


### PR DESCRIPTION
## Changes
- Add API error message for sign up and sign in
- Fix safe area and line height on sign up and sign in top text
- Refactor error messages to common
- Refactor request method to allow for different methods

## Screenshots
![image](https://user-images.githubusercontent.com/19786843/192167521-f31ab218-901e-46f9-9dbb-3871ab961112.png)
![image](https://user-images.githubusercontent.com/19786843/192167564-fb8053a2-eb29-44b6-9571-797e41fba95a.png)