### PR TITLE
CRYP-184: Refactor custom component themes to use custom typography

### DIFF
--- a/packages/client/theme/components/button.ts
+++ b/packages/client/theme/components/button.ts
@@ -38,8 +38,16 @@ export const button = {
             },
         },
     },
+    sizes: {
+        body: {
+            _text: {
+                fontSize: "body",
+                lineHeight: "body",
+            },
+        },
+    },
     defaultProps: {
         variant: "solid",
-        size: "lg",
+        size: "body",
     },
 };

--- a/packages/client/theme/components/form-control.ts
+++ b/packages/client/theme/components/form-control.ts
@@ -2,7 +2,8 @@ export const formControlErrorMessage = {
     baseStyle: {
         marginTop: "4px",
         _text: {
-            fontSize: "15",
+            fontSize: "subheadline",
+            lineHeight: "subheadline",
         },
     },
 };

--- a/packages/client/theme/components/input.ts
+++ b/packages/client/theme/components/input.ts
@@ -50,8 +50,14 @@ export const input = {
             },
         },
     },
+    sizes: {
+        callout: {
+            fontSize: "callout",
+            lineHeight: "callout",
+        },
+    },
     defaultProps: {
-        size: "lg",
+        size: "callout",
         variant: "outline",
     },
 };

--- a/packages/client/theme/components/text.ts
+++ b/packages/client/theme/components/text.ts
@@ -4,4 +4,57 @@ export const text = {
         fontFamily: "body",
         fontWeight: "regular",
     },
+    defaultProps: {
+        size: "body",
+    },
+    sizes: {
+        caption2: {
+            fontSize: "caption2",
+            lineHeight: "caption2",
+        },
+        caption1: {
+            fontSize: "caption1",
+            lineHeight: "caption1",
+        },
+        footnote2: {
+            fontSize: "footnote2",
+            lineHeight: "footnote2",
+        },
+        footnote1: {
+            fontSize: "footnote1",
+            lineHeight: "footnote1",
+        },
+        subheadline: {
+            fontSize: "subheadline",
+            lineHeight: "subheadline",
+        },
+        callout: {
+            fontSize: "callout",
+            lineHeight: "callout",
+        },
+        body: {
+            fontSize: "body",
+            lineHeight: "body",
+        },
+        headline: {
+            fontSize: "headline",
+            lineHeight: "headline",
+        },
+        title3: {
+            fontSize: "title3",
+            lineHeight: "title3",
+        },
+        title2: {
+            fontSize: "title2",
+            lineHeight: "title2",
+        },
+        title1: {
+            fontSize: "title1",
+            lineHeight: "title1",
+        },
+        largeTitle: {
+            fontSize: "largeTitle",
+            lineHeight: "largeTitle",
+        },
+    },
 };


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-184

## Changes

- Refactor the custom component themes (Text, Button, Input, FormErrorMessage) to use the custom typography
- Moving forward, there is no need to add the font size, font weight and line height CSS styling to the `Text` component

**Old**
```typescript
<Text style={styles.textStyle}>Text</Text>

textStyle: {
    fontSize: 20,
    lineHeight: 27,
    fontWeight: "600,
}
```

**New**
```typescript
<Text size={"title3"} fontWeight={"semibold"}>Text</Text>
```
## TODO

- Refactor all UI components to utilize the custom typography (will be done in a follow-up PR)