### PR TITLE
CRYP-101: Update wallet list when new wallet is added

### DIFF
--- a/packages/client/components/wallets-list/WalletsList.tsx
+++ b/packages/client/components/wallets-list/WalletsList.tsx
@@ -25,6 +25,9 @@ export default function WalletsList(props: Props) {
 
     React.useEffect(() => {
         (async () => {
+            // Get all the users wallets everytime the page comes in focus
+            // without this the home page (because of caching) and the settings page
+            // will not update when a new wallet is added
             if (isFocused) {
                 const wallets = await walletsGateway.findAllWallets({ id: user.id }, token);
                 setWallets(wallets);

--- a/packages/client/components/wallets-list/WalletsList.tsx
+++ b/packages/client/components/wallets-list/WalletsList.tsx
@@ -7,7 +7,7 @@ import { WalletsGateway } from "../../gateways/wallets_gateway";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { faWalletCustom } from "../icons/faWalletCustom";
 import { AuthContext } from "../contexts/AuthContext";
-import { CompositeNavigationProp } from "@react-navigation/native";
+import { CompositeNavigationProp, useIsFocused } from "@react-navigation/native";
 
 type Props = {
     showCurrencyTotals: boolean;
@@ -17,16 +17,20 @@ type Props = {
 export default function WalletsList(props: Props) {
     const walletsGateway = new WalletsGateway();
 
+    const isFocused = useIsFocused();
+
     const { token, user } = React.useContext(AuthContext);
 
     const [wallets, setWallets] = React.useState<WalletWithBalance[]>([]);
 
     React.useEffect(() => {
         (async () => {
-            const wallets = await walletsGateway.findAllWallets({ id: user.id }, token);
-            setWallets(wallets);
+            if (isFocused) {
+                const wallets = await walletsGateway.findAllWallets({ id: user.id }, token);
+                setWallets(wallets);
+            }
         })();
-    }, []);
+    }, [isFocused]);
 
     return wallets ? (
         <ScrollView style={styles.scrollView}>


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-101

## Changes
Previously when a new wallet was added it wouldnt show up on the home screen until the app was restarted because the page is cached so the api call would never happen again, and would only show through the setting page if you navigated away then back to it. Now anytime the page containing the wallets list comes into focus again we will make a new api request to get the users wallets.