### PR TITLE
CRYP-120: refactor address validation to library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,16 @@ jobs:
               run: docker run --entrypoint yarn cryptify-btc-edge lint:check
             - name: Unit test
               run: docker run --entrypoint yarn cryptify-btc-edge workspace @cryptify/btc-edge test:unit
+    common:
+        name: Common
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Build image
+              run: docker build -t cryptify-api -f packages/docker/api.Dockerfile --target development .
+            - name: Unit test
+              run: docker run --entrypoint yarn cryptify-api workspace @cryptify/common test:unit
     integration-tests:
         name: Integration Tests
         runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
         "eth-edge:test": "yarn workspace @cryptify/eth-edge test",
         "btc-edge:dev": "yarn workspace @cryptify/btc-edge start:dev",
         "btc-edge:test": "yarn workspace @cryptify/btc-edge test",
-        "common:test": "yarn workspace @cryptify/common test",
         "lint:check": "eslint '*/**/*.{js,jsx,ts,tsx,json}' --max-warnings=0",
         "lint:fix": "eslint '*/**/*.{js,jsx,ts,tsx,json}' --fix"
     },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "eth-edge:test": "yarn workspace @cryptify/eth-edge test",
         "btc-edge:dev": "yarn workspace @cryptify/btc-edge start:dev",
         "btc-edge:test": "yarn workspace @cryptify/btc-edge test",
+        "common:test": "yarn workspace @cryptify/common test",
         "lint:check": "eslint '*/**/*.{js,jsx,ts,tsx,json}' --max-warnings=0",
         "lint:fix": "eslint '*/**/*.{js,jsx,ts,tsx,json}' --fix"
     },

--- a/packages/btc-edge/test/integration/wallet_api.spec.ts
+++ b/packages/btc-edge/test/integration/wallet_api.spec.ts
@@ -5,6 +5,8 @@ import { INestApplication } from "@nestjs/common";
 import { seedDB } from "@cryptify/common/src/db/seed_db";
 
 describe("Wallets", () => {
+    jest.setTimeout(10000);
+
     let app: INestApplication;
 
     beforeAll(async () => {

--- a/packages/client/components/AddressShareButton.tsx
+++ b/packages/client/components/AddressShareButton.tsx
@@ -3,20 +3,18 @@ import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { Pressable } from "native-base";
 import React from "react";
 import { Share } from "react-native";
-import { currencyTagToName } from "../services/currency_service";
 import { faArrowUpBracket } from "./icons/regular/farArrowUpFromBracket";
+import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 
 type Props = {
-    currencyType: string;
+    currencyType: CurrencyType;
     address: string;
 };
 
 export function AddressShareButton({ currencyType, address }: Props) {
-    const currencyName = currencyTagToName.get(currencyType);
-
     async function onShare() {
         await Share.share({
-            message: `${titleCase(currencyName ? currencyName : "")} Wallet Address:\r\n${address}`,
+            message: `${titleCase(currencyType)} Wallet Address:\r\n${address}`,
         });
     }
 

--- a/packages/client/components/TransactionDetails.tsx
+++ b/packages/client/components/TransactionDetails.tsx
@@ -7,9 +7,10 @@ import { falCircleArrowDownLeft } from "./icons/light/falCircleArrowDownLeft";
 import { falCircleArrowUpRight } from "./icons/light/falCircleArrowUpRight";
 import { farCopy } from "./icons/regular/farCopy";
 import * as Clipboard from "expo-clipboard";
-import { getFormattedAmount } from "../services/currency_service";
+import { getFormattedAmount, typeToISOCode } from "../services/currency_service";
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 import { formatAddress } from "../services/address_service";
+import { getCurrencyType } from "@cryptify/common/src/utils/currency_utils";
 
 type Props = {
     transaction: Transaction;
@@ -17,32 +18,30 @@ type Props = {
 };
 
 export function TransactionDetails({ transaction, walletAddress }: Props) {
-    const isIncommingTransaction = walletAddress == transaction.walletIn;
+    const isIncomingTransaction = walletAddress == transaction.walletIn;
 
     const copyToClipboard = async (valueToCopy: string) => {
         await Clipboard.setStringAsync(valueToCopy);
     };
 
-    function getCurrencyType(): string {
-        return transaction.transactionAddress.substring(0, 2) == "0x" ? "ETH" : "BTC";
-    }
-
     const renderHeader = (
         <Box style={styles.itemWrapper} testID="transactionDetailsHeader">
             <VStack>
                 <FontAwesomeIcon
-                    icon={isIncommingTransaction ? falCircleArrowDownLeft : falCircleArrowUpRight}
-                    style={isIncommingTransaction ? styles.receiveIcon : styles.sendIcon}
+                    icon={isIncomingTransaction ? falCircleArrowDownLeft : falCircleArrowUpRight}
+                    style={isIncomingTransaction ? styles.receiveIcon : styles.sendIcon}
                     size={48}
                 />
                 <Text
                     size={"title2"}
                     fontWeight={"semibold"}
-                    color={isIncommingTransaction ? "success.600" : undefined}
+                    color={isIncomingTransaction ? "success.600" : undefined}
                     style={styles.transactionAmountInOut}
                 >
-                    {isIncommingTransaction ? "+" : "-"}
-                    {getFormattedAmount(transaction.amount, CurrencyType.ETHEREUM) + " "} {getCurrencyType()}
+                    {isIncomingTransaction ? "+" : "-"}
+                    {`${getFormattedAmount(transaction.amount, CurrencyType.ETHEREUM)} ${
+                        typeToISOCode[getCurrencyType(transaction.transactionAddress)]
+                    }`}
                 </Text>
                 <Text fontWeight={"semibold"} color="text.500" style={styles.transactionsAddress}>
                     {formatAddress(transaction.transactionAddress)}
@@ -82,7 +81,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                     </Text>
                     <HStack space="10px">
                         <Text style={styles.elementInformationText}>{transaction.walletIn}</Text>
-                        {isIncommingTransaction ? (
+                        {isIncomingTransaction ? (
                             <Pressable onPress={() => copyToClipboard(transaction.walletIn)}>
                                 <FontAwesomeIcon icon={farCopy} style={styles.copyIcon} size={20} />
                             </Pressable>
@@ -97,7 +96,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                     </Text>
                     <HStack space="10px">
                         <Text style={styles.elementInformationText}>{transaction.walletOut}</Text>
-                        {isIncommingTransaction ? (
+                        {isIncomingTransaction ? (
                             <></>
                         ) : (
                             <Pressable onPress={() => copyToClipboard(transaction.walletOut)}>

--- a/packages/client/components/transactions-list/TransactionListItem.tsx
+++ b/packages/client/components/transactions-list/TransactionListItem.tsx
@@ -7,8 +7,9 @@ import { falCircleArrowDownLeft } from "../icons/light/falCircleArrowDownLeft";
 import { falCircleArrowUpRight } from "../icons/light/falCircleArrowUpRight";
 import { CompositeNavigationProp } from "@react-navigation/native";
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
-import { getFormattedAmount } from "../../services/currency_service";
+import { getFormattedAmount, typeToISOCode } from "../../services/currency_service";
 import { formatAddress } from "../../services/address_service";
+import { getCurrencyType } from "@cryptify/common/src/utils/currency_utils";
 
 type Props = {
     transaction: Transaction;
@@ -18,10 +19,6 @@ type Props = {
 
 export function TransactionListItem({ transaction, walletAddress, navigation }: Props) {
     const isIncomingTransaction = walletAddress == transaction.walletIn;
-
-    function getCurrencyType(): string {
-        return transaction.transactionAddress.substring(0, 2) == "0x" ? "ETH" : "BTC";
-    }
 
     function getFormattedDate(timestamp: string): string {
         const date = new Date(timestamp);
@@ -73,7 +70,7 @@ export function TransactionListItem({ transaction, walletAddress, navigation }: 
                                 {getFormattedDate(transaction.createdAt as any)}
                             </Text>
                             <Text size={"subheadline"} color="text.500" style={styles.transactionCurrency}>
-                                {getCurrencyType()}
+                                {typeToISOCode[getCurrencyType(transaction.transactionAddress)]}
                             </Text>
                         </HStack>
                     </VStack>

--- a/packages/client/components/wallets-list/WalletsListAccordion.tsx
+++ b/packages/client/components/wallets-list/WalletsListAccordion.tsx
@@ -31,7 +31,7 @@ export function WalletsListAccordion({ wallets, showCurrencyTotals, navigation }
         [CurrencyType.ETHEREUM]: [],
     });
 
-    function formatTitle(currencyType: string, address: string): string {
+    function formatTitle(currencyType: CurrencyType, address: string): string {
         return `${titleCase(currencyType)} ${formatAddress(address)}`;
     }
 
@@ -90,7 +90,7 @@ export function WalletsListAccordion({ wallets, showCurrencyTotals, navigation }
                                 title: formatTitle(wallet.currencyType, wallet.address),
                                 address: wallet.address.toLowerCase(),
                                 name: wallet.name,
-                                currencyType: currency.currencyTag,
+                                currencyType: currency.type,
                                 balance: getFormattedAmount(wallet.balance, currency.type),
                             });
                         }}

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -37,7 +37,7 @@ import WalletDetailsScreen from "../screens/WalletDetailsScreen";
 import WalletOverviewScreen from "../screens/WalletOverviewScreen";
 import TransactionsListScreen from "../screens/TransactionsListScreen";
 import WalletQRCodeScreen from "../screens/WalletQRCodeScreen";
-import { AddressShareButton } from "../components/ShareButton";
+import { AddressShareButton } from "../components/AddressShareButton";
 
 // TODO refactor this file to reduce code duplication and see if
 // there is a way to centralize some of the styling between

--- a/packages/client/screens/WalletOverviewScreen.tsx
+++ b/packages/client/screens/WalletOverviewScreen.tsx
@@ -16,6 +16,7 @@ import { farQrCode } from "../components/icons/regular/farQrCode";
 import { getTransactionByWallet } from "../services/transaction_service";
 import { formatAddress } from "../services/address_service";
 import { TransactionsList } from "../components/transactions-list/TransactionsList";
+import { typeToISOCode } from "../services/currency_service";
 
 type Props = CompositeScreenProps<
     HomeStackScreenProps<"WalletOverviewScreen">,
@@ -59,7 +60,7 @@ export default function WalletOverviewScreen({ route, navigation }: Props) {
                         <VStack>
                             <Box marginTop="40px" marginBottom="0"></Box>
                             <Text size={"subheadline"} color={"text.500"}>
-                                {currencyType}
+                                {typeToISOCode[currencyType]}
                             </Text>
                             <Text size={"title3"}>{balance}</Text>
                         </VStack>

--- a/packages/client/screens/WalletQRCodeScreen.tsx
+++ b/packages/client/screens/WalletQRCodeScreen.tsx
@@ -4,7 +4,7 @@ import { Text, HStack, Center, VStack } from "native-base";
 import { HomeStackScreenProps, SettingsStackScreenProps } from "../types";
 import React from "react";
 import { CompositeScreenProps } from "@react-navigation/native";
-import { currencyTagToName } from "../services/currency_service";
+import { typeToISOCode } from "../services/currency_service";
 import { titleCase } from "@cryptify/common/src/utils/string_utils";
 import QRCode from "react-native-qrcode-svg";
 import RowItem from "../components/RowItem";
@@ -19,14 +19,13 @@ type Props = CompositeScreenProps<
 
 export default function WalletQRCodeScreen({ route }: Props) {
     const { address, name, currencyType } = route.params;
-    const currencyName = currencyTagToName.get(currencyType);
 
     return (
         <View style={styles.view}>
             <Text size={"subheadline"} testID="QRCodeHeader">
                 Copy and share this information to add{" "}
                 <Text style={{ fontWeight: "600" }}>
-                    {titleCase(currencyName ? currencyName : "")} ({currencyType}){" "}
+                    {titleCase(currencyType)} ({typeToISOCode[currencyType]}){" "}
                 </Text>
                 from another source. A{" "}
                 <Text style={{ fontWeight: "600" }} underline>
@@ -55,8 +54,8 @@ export default function WalletQRCodeScreen({ route }: Props) {
             <HStack style={styles.info} testID="QRCodeWarning">
                 <FontAwesomeIcon icon={farCircleInfo} size={16} />
                 <Text size={"footnote2"} style={styles.infoText}>
-                    Never enter this address by hand and only send {titleCase(currencyName ? currencyName : "")} (
-                    {currencyType}) to this address.
+                    Never enter this address by hand and only send {titleCase(currencyType)} (
+                    {typeToISOCode[currencyType]}) to this address.
                 </Text>
             </HStack>
         </View>

--- a/packages/client/services/currency_service.ts
+++ b/packages/client/services/currency_service.ts
@@ -22,7 +22,9 @@ export function getFormattedAmount(amount: string, type: CurrencyType): string {
     return parts.join(".");
 }
 
-export const currencyTagToName = new Map<string, CurrencyType>([
-    ["ETH", CurrencyType.ETHEREUM],
-    ["BTC", CurrencyType.BITCOIN],
-]);
+type ISOCode = "ETH" | "BTC";
+
+export const typeToISOCode: { [key in CurrencyType]: ISOCode } = {
+    [CurrencyType.ETHEREUM]: "ETH",
+    [CurrencyType.BITCOIN]: "BTC",
+};

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -32,14 +32,14 @@ type WalletOverviewScreenProps = {
     title: string;
     address: string;
     name: string;
-    currencyType: string;
+    currencyType: CurrencyType;
     balance: string;
 };
 
 type WalletDetailsScreenProps = {
     address: string;
     name: string;
-    currencyType: string;
+    currencyType: CurrencyType;
     balance: string;
     transactions: Transaction[];
 };
@@ -47,7 +47,7 @@ type WalletDetailsScreenProps = {
 type WalletQRCodeProps = {
     address: string;
     name: string;
-    currencyType: string;
+    currencyType: CurrencyType;
 };
 
 type TransactionsListScreenProps = {

--- a/packages/common/jest-config-unit.json
+++ b/packages/common/jest-config-unit.json
@@ -1,0 +1,9 @@
+{
+    "moduleFileExtensions": ["js", "json", "ts"],
+    "rootDir": ".",
+    "testEnvironment": "node",
+    "testMatch": ["<rootDir>/test/unit/**/*.spec.ts"],
+    "transform": {
+        "^.+\\.ts$": "ts-jest"
+    }
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,6 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
+        "test": "NODE_ENV=test jest --config jest-config.json --verbose --coverage",
         "build": "tsc",
         "db:seed": "DOTENV_CONFIG_PATH=.env.test ts-node src/db/scripts/run_seed_db.ts -r dotenv/config"
     },
@@ -13,10 +14,14 @@
         "dotenv": "^16.0.3",
         "node-fetch": "^2.6.7",
         "typeorm": "^0.3.9",
+        "wallet-address-validator": "^0.2.4",
         "yup": "^0.32.11"
     },
     "devDependencies": {
+        "@types/jest": "^29.2.2",
         "@types/node-fetch": "^2.6.2",
+        "jest": "^29.3.1",
+        "ts-jest": "^29.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^4.7.4"
     }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "private": true,
     "scripts": {
-        "test": "NODE_ENV=test jest --config jest-config.json --verbose --coverage",
+        "test:unit": "NODE_ENV=test jest --config jest-config-unit.json --verbose",
         "build": "tsc",
         "db:seed": "DOTENV_CONFIG_PATH=.env.test ts-node src/db/scripts/run_seed_db.ts -r dotenv/config"
     },

--- a/packages/common/src/utils/currency_utils.ts
+++ b/packages/common/src/utils/currency_utils.ts
@@ -1,11 +1,13 @@
-import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
+import {CurrencyType} from "@cryptify/common/src/domain/currency_type";
+import {validate} from "wallet-address-validator";
 
 export function getCurrencyType(address: string): CurrencyType {
-    // TODO these regex are not good at all and should be refactored
-    // to either a formal implementation in the system or using
-    // a well known package
-    if (address.includes("0x")) return CurrencyType.ETHEREUM;
-    if (/^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$/.test(address)) return CurrencyType.BITCOIN;
+    if (validate(address, 'BTC')) {
+        return CurrencyType.BITCOIN
+    }
+    if (validate(address, 'ETH')) {
+        return CurrencyType.ETHEREUM
+    }
 
     throw new Error("Currency type not supported");
 }

--- a/packages/common/src/utils/currency_utils.ts
+++ b/packages/common/src/utils/currency_utils.ts
@@ -12,7 +12,6 @@ export function getCurrencyType(address: string): CurrencyType {
         return CurrencyType.ETHEREUM;
     }
 
-    console.log(address.length);
     throw new Error("Currency type not supported");
 }
 

--- a/packages/common/src/utils/currency_utils.ts
+++ b/packages/common/src/utils/currency_utils.ts
@@ -1,12 +1,12 @@
-import {CurrencyType} from "@cryptify/common/src/domain/currency_type";
-import {validate} from "wallet-address-validator";
+import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
+import { validate } from "wallet-address-validator";
 
 export function getCurrencyType(address: string): CurrencyType {
-    if (validate(address, 'BTC')) {
-        return CurrencyType.BITCOIN
+    if (validate(address, "BTC")) {
+        return CurrencyType.BITCOIN;
     }
-    if (validate(address, 'ETH')) {
-        return CurrencyType.ETHEREUM
+    if (validate(address, "ETH")) {
+        return CurrencyType.ETHEREUM;
     }
 
     throw new Error("Currency type not supported");

--- a/packages/common/src/utils/currency_utils.ts
+++ b/packages/common/src/utils/currency_utils.ts
@@ -1,14 +1,18 @@
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 import { validate } from "wallet-address-validator";
 
+const btcTxRegex = /^[a-fA-F0-9]{64}$/;
+const ethTxRegex = /^0x([A-Fa-f0-9]{64})$/;
+
 export function getCurrencyType(address: string): CurrencyType {
-    if (validate(address, "BTC")) {
+    if (validate(address, "BTC") || btcTxRegex.test(address)) {
         return CurrencyType.BITCOIN;
     }
-    if (validate(address, "ETH")) {
+    if (validate(address, "ETH") || ethTxRegex.test(address)) {
         return CurrencyType.ETHEREUM;
     }
 
+    console.log(address.length);
     throw new Error("Currency type not supported");
 }
 

--- a/packages/common/test/unit/currency_utils.spec.ts
+++ b/packages/common/test/unit/currency_utils.spec.ts
@@ -1,43 +1,41 @@
-import {getCurrencyType} from "@cryptify/common/src/utils/currency_utils";
-import {CurrencyType} from "@cryptify/common/src/domain/currency_type";
+import { getCurrencyType } from "@cryptify/common/src/utils/currency_utils";
+import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 
 describe("currency_utils", () => {
     describe("getCurrencyType", () => {
         it("should return BTC for all BTC wallet addresses", () => {
             const btcWalletAddresses = [
                 "17RvZXYD9fwpWqk6G2RXWj1L3sfh3Roqjr",
-                "bc1q22jrgjeg5mm9zuzlxv90snrfhelm0hy76hsra2"
+                "bc1q22jrgjeg5mm9zuzlxv90snrfhelm0hy76hsra2",
             ];
             const types = btcWalletAddresses.map((addr) => getCurrencyType(addr));
             expect(types.every((type) => type === CurrencyType.BITCOIN)).toBeTruthy();
-        })
+        });
 
         it("should return BTC for all BTC transaction addresses", () => {
             const btcTxAddresses = [
                 "6cb2ee7bb65ba2ee2fb6a063574ef166bf68d3b58a2c03e0090df0e6fc925eef",
                 "23868be858d7e09af120ec5f66a3fdf9ab5f106b490988dc415580fe0181a8b2",
-                "0bf1f3c367636b74a7edb7979a7e09452be4bbf552379ddbf173719a83ba21a9"
+                "0bf1f3c367636b74a7edb7979a7e09452be4bbf552379ddbf173719a83ba21a9",
             ];
             const types = btcTxAddresses.map((addr) => getCurrencyType(addr));
             expect(types.every((type) => type === CurrencyType.BITCOIN)).toBeTruthy();
-        })
+        });
 
         it("should return ETH for all ETH wallet addresses", () => {
-            const ethWalletAddresses = [
-                "0x1eaA86A15Cb8818b18237B6e1dC2faA83de0c251",
-            ];
+            const ethWalletAddresses = ["0x1eaA86A15Cb8818b18237B6e1dC2faA83de0c251"];
             const types = ethWalletAddresses.map((addr) => getCurrencyType(addr));
             expect(types.every((type) => type === CurrencyType.ETHEREUM)).toBeTruthy();
-        })
+        });
 
         it("should return ETH for all ETH transaction addresses", () => {
             const ethTxAddresses = [
                 "0x7e2895f51092a8f2239d9f2a2c0bdbf6e4c74d2d07a19b72e7975861ca8442c4",
                 "0x6f37cc6db1034c2112c5508ae6dad9bd57d03b2b362a29aa2ff7436d4bc58a21",
-                "0xd5673ff963616bef8a3088906006f5b01ad340d9ec3bdfb75436cd935f2942d9"
+                "0xd5673ff963616bef8a3088906006f5b01ad340d9ec3bdfb75436cd935f2942d9",
             ];
             const types = ethTxAddresses.map((addr) => getCurrencyType(addr));
             expect(types.every((type) => type === CurrencyType.ETHEREUM)).toBeTruthy();
-        })
-    })
-})
+        });
+    });
+});

--- a/packages/common/test/unit/currency_utils.spec.ts
+++ b/packages/common/test/unit/currency_utils.spec.ts
@@ -1,0 +1,43 @@
+import {getCurrencyType} from "@cryptify/common/src/utils/currency_utils";
+import {CurrencyType} from "@cryptify/common/src/domain/currency_type";
+
+describe("currency_utils", () => {
+    describe("getCurrencyType", () => {
+        it("should return BTC for all BTC wallet addresses", () => {
+            const btcWalletAddresses = [
+                "17RvZXYD9fwpWqk6G2RXWj1L3sfh3Roqjr",
+                "bc1q22jrgjeg5mm9zuzlxv90snrfhelm0hy76hsra2"
+            ];
+            const types = btcWalletAddresses.map((addr) => getCurrencyType(addr));
+            expect(types.every((type) => type === CurrencyType.BITCOIN)).toBeTruthy();
+        })
+
+        it("should return BTC for all BTC transaction addresses", () => {
+            const btcTxAddresses = [
+                "6cb2ee7bb65ba2ee2fb6a063574ef166bf68d3b58a2c03e0090df0e6fc925eef",
+                "23868be858d7e09af120ec5f66a3fdf9ab5f106b490988dc415580fe0181a8b2",
+                "0bf1f3c367636b74a7edb7979a7e09452be4bbf552379ddbf173719a83ba21a9"
+            ];
+            const types = btcTxAddresses.map((addr) => getCurrencyType(addr));
+            expect(types.every((type) => type === CurrencyType.BITCOIN)).toBeTruthy();
+        })
+
+        it("should return ETH for all ETH wallet addresses", () => {
+            const ethWalletAddresses = [
+                "0x1eaA86A15Cb8818b18237B6e1dC2faA83de0c251",
+            ];
+            const types = ethWalletAddresses.map((addr) => getCurrencyType(addr));
+            expect(types.every((type) => type === CurrencyType.ETHEREUM)).toBeTruthy();
+        })
+
+        it("should return ETH for all ETH transaction addresses", () => {
+            const ethTxAddresses = [
+                "0x7e2895f51092a8f2239d9f2a2c0bdbf6e4c74d2d07a19b72e7975861ca8442c4",
+                "0x6f37cc6db1034c2112c5508ae6dad9bd57d03b2b362a29aa2ff7436d4bc58a21",
+                "0xd5673ff963616bef8a3088906006f5b01ad340d9ec3bdfb75436cd935f2942d9"
+            ];
+            const types = ethTxAddresses.map((addr) => getCurrencyType(addr));
+            expect(types.every((type) => type === CurrencyType.ETHEREUM)).toBeTruthy();
+        })
+    })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,7 +829,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.18.6":
+"@babel/plugin-syntax-jsx@npm:^7.0.0, @babel/plugin-syntax-jsx@npm:^7.18.6, @babel/plugin-syntax-jsx@npm:^7.7.2":
   version: 7.18.6
   resolution: "@babel/plugin-syntax-jsx@npm:7.18.6"
   dependencies:
@@ -1784,12 +1784,16 @@ __metadata:
     "@nestjs/common": ^9.0.0
     "@nestjs/config": ^2.2.0
     "@nestjs/core": ^9.0.0
+    "@types/jest": ^29.2.2
     "@types/node-fetch": ^2.6.2
     dotenv: ^16.0.3
+    jest: ^29.3.1
     node-fetch: ^2.6.7
+    ts-jest: ^29.0.3
     ts-node: ^10.9.1
     typeorm: ^0.3.9
     typescript: ^4.7.4
+    wallet-address-validator: ^0.2.4
     yup: ^0.32.11
   languageName: unknown
   linkType: soft
@@ -3120,6 +3124,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/console@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/console@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
+    slash: ^3.0.0
+  checksum: 9eecbfb6df4f5b810374849b7566d321255e6fd6e804546236650384966be532ff75a3e445a3277eadefe67ddf4dc56cd38332abd72d6a450f1bea9866efc6d7
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/core@npm:27.5.1"
@@ -3203,6 +3221,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/core@npm:29.3.1"
+  dependencies:
+    "@jest/console": ^29.3.1
+    "@jest/reporters": ^29.3.1
+    "@jest/test-result": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    jest-changed-files: ^29.2.0
+    jest-config: ^29.3.1
+    jest-haste-map: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.3.1
+    jest-resolve-dependencies: ^29.3.1
+    jest-runner: ^29.3.1
+    jest-runtime: ^29.3.1
+    jest-snapshot: ^29.3.1
+    jest-util: ^29.3.1
+    jest-validate: ^29.3.1
+    jest-watcher: ^29.3.1
+    micromatch: ^4.0.4
+    pretty-format: ^29.3.1
+    slash: ^3.0.0
+    strip-ansi: ^6.0.0
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: e3ac9201e8a084ccd832b17877b56490402b919f227622bb24f9372931e77b869e60959d34144222ce20fb619d0a6a6be20b257adb077a6b0f430a4584a45b0f
+  languageName: node
+  linkType: hard
+
 "@jest/create-cache-key-function@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/create-cache-key-function@npm:26.6.2"
@@ -3245,6 +3304,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/environment@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/environment@npm:29.3.1"
+  dependencies:
+    "@jest/fake-timers": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    jest-mock: ^29.3.1
+  checksum: 974102aba7cc80508f787bb5504dcc96e5392e0a7776a63dffbf54ddc2c77d52ef4a3c08ed2eedec91965befff873f70cd7c9ed56f62bb132dcdb821730e6076
+  languageName: node
+  linkType: hard
+
 "@jest/expect-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/expect-utils@npm:28.1.3"
@@ -3263,6 +3334,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/expect-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/expect-utils@npm:29.3.1"
+  dependencies:
+    jest-get-type: ^29.2.0
+  checksum: 7f3b853eb1e4299988f66b9aa49c1aacb7b8da1cf5518dca4ccd966e865947eed8f1bde6c8f5207d8400e9af870112a44b57aa83515ad6ea5e4a04a971863adb
+  languageName: node
+  linkType: hard
+
 "@jest/expect@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/expect@npm:28.1.3"
@@ -3270,6 +3350,16 @@ __metadata:
     expect: ^28.1.3
     jest-snapshot: ^28.1.3
   checksum: 4197f6fdddc33dc45ba4e838f992fc61839c421d7aed0dfe665ef9c2f172bb1df8a8cac9cecee272b40e744a326da521d5e182709fe82a0b936055bfffa3b473
+  languageName: node
+  linkType: hard
+
+"@jest/expect@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/expect@npm:29.3.1"
+  dependencies:
+    expect: ^29.3.1
+    jest-snapshot: ^29.3.1
+  checksum: 1d7b5cc735c8a99bfbed884d80fdb43b23b3456f4ec88c50fd86404b097bb77fba84f44e707fc9b49f106ca1154ae03f7c54dc34754b03f8a54eeb420196e5bf
   languageName: node
   linkType: hard
 
@@ -3301,6 +3391,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/fake-timers@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/fake-timers@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@sinonjs/fake-timers": ^9.1.2
+    "@types/node": "*"
+    jest-message-util: ^29.3.1
+    jest-mock: ^29.3.1
+    jest-util: ^29.3.1
+  checksum: b1dafa8cdc439ef428cd772c775f0b22703677f52615513eda11a104bbfc352d7ec69b1225db95d4ef2e1b4ef0f23e1a7d96de5313aeb0950f672e6548ae069d
+  languageName: node
+  linkType: hard
+
 "@jest/globals@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/globals@npm:27.5.1"
@@ -3320,6 +3424,18 @@ __metadata:
     "@jest/expect": ^28.1.3
     "@jest/types": ^28.1.3
   checksum: 3504bb23de629d466c6f2b6b75d2e1c1b10caccbbcfb7eaa82d22cc37711c8e364c243929581184846605c023b475ea6c42c2e3ea5994429a988d8d527af32cd
+  languageName: node
+  linkType: hard
+
+"@jest/globals@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/globals@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/expect": ^29.3.1
+    "@jest/types": ^29.3.1
+    jest-mock: ^29.3.1
+  checksum: 4d2b9458aabf7c28fd167e53984477498c897b64eec67a7f84b8fff465235cae1456ee0721cb0e7943f0cda443c7656adb9801f9f34e27495b8ebbd9f3033100
   languageName: node
   linkType: hard
 
@@ -3399,6 +3515,43 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/reporters@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/reporters@npm:29.3.1"
+  dependencies:
+    "@bcoe/v8-coverage": ^0.2.3
+    "@jest/console": ^29.3.1
+    "@jest/test-result": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@jridgewell/trace-mapping": ^0.3.15
+    "@types/node": "*"
+    chalk: ^4.0.0
+    collect-v8-coverage: ^1.0.0
+    exit: ^0.1.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    istanbul-lib-coverage: ^3.0.0
+    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-report: ^3.0.0
+    istanbul-lib-source-maps: ^4.0.0
+    istanbul-reports: ^3.1.3
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
+    jest-worker: ^29.3.1
+    slash: ^3.0.0
+    string-length: ^4.0.1
+    strip-ansi: ^6.0.0
+    v8-to-istanbul: ^9.0.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 273e0c6953285f01151e9d84ac1e55744802a1ec79fb62dafeea16a49adfe7b24e7f35bef47a0214e5e057272dbfdacf594208286b7766046fd0f3cfa2043840
+  languageName: node
+  linkType: hard
+
 "@jest/schemas@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/schemas@npm:28.1.3"
@@ -3439,6 +3592,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/source-map@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "@jest/source-map@npm:29.2.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.15
+    callsites: ^3.0.0
+    graceful-fs: ^4.2.9
+  checksum: 09f76ab63d15dcf44b3035a79412164f43be34ec189575930f1a00c87e36ea0211ebd6a4fbe2253c2516e19b49b131f348ddbb86223ca7b6bbac9a6bc76ec96e
+  languageName: node
+  linkType: hard
+
 "@jest/test-result@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/test-result@npm:27.5.1"
@@ -3463,6 +3627,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/test-result@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/test-result@npm:29.3.1"
+  dependencies:
+    "@jest/console": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/istanbul-lib-coverage": ^2.0.0
+    collect-v8-coverage: ^1.0.0
+  checksum: b24ac283321189b624c372a6369c0674b0ee6d9e3902c213452c6334d037113718156b315364bee8cee0f03419c2bdff5e2c63967193fb422830e79cbb26866a
+  languageName: node
+  linkType: hard
+
 "@jest/test-sequencer@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/test-sequencer@npm:27.5.1"
@@ -3484,6 +3660,18 @@ __metadata:
     jest-haste-map: ^28.1.3
     slash: ^3.0.0
   checksum: 13f8905e6d1ec8286694146f7be3cf90eff801bbdea5e5c403e6881444bb390ed15494c7b9948aa94bd7e9c9a851e0d3002ed6e7371d048b478596e5b23df953
+  languageName: node
+  linkType: hard
+
+"@jest/test-sequencer@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/test-sequencer@npm:29.3.1"
+  dependencies:
+    "@jest/test-result": ^29.3.1
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.3.1
+    slash: ^3.0.0
+  checksum: a8325b1ea0ce644486fb63bb67cedd3524d04e3d7b1e6c1e3562bf12ef477ecd0cf34044391b2a07d925e1c0c8b4e0f3285035ceca3a474a2c55980f1708caf3
   languageName: node
   linkType: hard
 
@@ -3556,6 +3744,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/transform@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/transform@npm:29.3.1"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/types": ^29.3.1
+    "@jridgewell/trace-mapping": ^0.3.15
+    babel-plugin-istanbul: ^6.1.1
+    chalk: ^4.0.0
+    convert-source-map: ^2.0.0
+    fast-json-stable-stringify: ^2.1.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.3.1
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.3.1
+    micromatch: ^4.0.4
+    pirates: ^4.0.4
+    slash: ^3.0.0
+    write-file-atomic: ^4.0.1
+  checksum: 673df5900ffc95bc811084e09d6e47948034dea6ab6cc4f81f80977e3a52468a6c2284d0ba9796daf25a62ae50d12f7e97fc9a3a0c587f11f2a479ff5493ca53
+  languageName: node
+  linkType: hard
+
 "@jest/types@npm:^26.6.2":
   version: 26.6.2
   resolution: "@jest/types@npm:26.6.2"
@@ -3610,6 +3821,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/types@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "@jest/types@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    "@types/istanbul-lib-coverage": ^2.0.0
+    "@types/istanbul-reports": ^3.0.0
+    "@types/node": "*"
+    "@types/yargs": ^17.0.8
+    chalk: ^4.0.0
+  checksum: 6f9faf27507b845ff3839c1adc6dbd038d7046d03d37e84c9fc956f60718711a801a5094c7eeee6b39ccf42c0ab61347fdc0fa49ab493ae5a8efd2fd41228ee8
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.1.0":
   version: 0.1.1
   resolution: "@jridgewell/gen-mapping@npm:0.1.1"
@@ -3631,7 +3856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3":
+"@jridgewell/resolve-uri@npm:3.1.0, @jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.1.0
   resolution: "@jridgewell/resolve-uri@npm:3.1.0"
   checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
@@ -3655,7 +3880,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/sourcemap-codec@npm:1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.14
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
   checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
@@ -3679,6 +3904,16 @@ __metadata:
     "@jridgewell/resolve-uri": ^3.0.3
     "@jridgewell/sourcemap-codec": ^1.4.10
   checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.15":
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  dependencies:
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
   languageName: node
   linkType: hard
 
@@ -5722,6 +5957,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/jest@npm:^29.2.2":
+  version: 29.2.2
+  resolution: "@types/jest@npm:29.2.2"
+  dependencies:
+    expect: ^29.0.0
+    pretty-format: ^29.0.0
+  checksum: 13b1a48858c8c451109c2838205fdcee6f41d672674d2f0e3cada35e94f133370aba4f4b5c3f5b174f3e16244d76d7d718afa7cc67d4d6f90d1b87951f4c87c3
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:*, @types/json-schema@npm:^7.0.5, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.11
   resolution: "@types/json-schema@npm:7.0.11"
@@ -7354,6 +7599,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-jest@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "babel-jest@npm:29.3.1"
+  dependencies:
+    "@jest/transform": ^29.3.1
+    "@types/babel__core": ^7.1.14
+    babel-plugin-istanbul: ^6.1.1
+    babel-preset-jest: ^29.2.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    slash: ^3.0.0
+  peerDependencies:
+    "@babel/core": ^7.8.0
+  checksum: 793848238a771a931ddeb5930b9ec8ab800522ac8d64933665698f4a39603d157e572e20b57d79610277e1df88d3ee82b180d59a21f3570388f602beeb38a595
+  languageName: node
+  linkType: hard
+
 "babel-loader@npm:8.1.0":
   version: 8.1.0
   resolution: "babel-loader@npm:8.1.0"
@@ -7425,6 +7687,18 @@ __metadata:
     "@types/babel__core": ^7.1.14
     "@types/babel__traverse": ^7.0.6
   checksum: 648d89f9d80f6450ce7e50d0c32eb91b7f26269b47c3e37aaf2e0f2f66a980978345bd6b8c9b8c3aa6a8252ad2bc2c9fb50630e9895622c9a0972af5f70ed20e
+  languageName: node
+  linkType: hard
+
+"babel-plugin-jest-hoist@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "babel-plugin-jest-hoist@npm:29.2.0"
+  dependencies:
+    "@babel/template": ^7.3.3
+    "@babel/types": ^7.3.3
+    "@types/babel__core": ^7.1.14
+    "@types/babel__traverse": ^7.0.6
+  checksum: 368d271ceae491ae6b96cd691434859ea589fbe5fd5aead7660df75d02394077273c6442f61f390e9347adffab57a32b564d0fabcf1c53c4b83cd426cb644072
   languageName: node
   linkType: hard
 
@@ -7600,6 +7874,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"babel-preset-jest@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "babel-preset-jest@npm:29.2.0"
+  dependencies:
+    babel-plugin-jest-hoist: ^29.2.0
+    babel-preset-current-node-syntax: ^1.0.0
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 1b09a2db968c36e064daf98082cfffa39c849b63055112ddc56fc2551fd0d4783897265775b1d2f8a257960a3339745de92e74feb01bad86d41c4cecbfa854fc
+  languageName: node
+  linkType: hard
+
 "balanced-match@npm:^1.0.0":
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
@@ -7607,7 +7893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base-x@npm:^3.0.2, base-x@npm:^3.0.8":
+"base-x@npm:^3.0.2, base-x@npm:^3.0.4, base-x@npm:^3.0.8":
   version: 3.0.9
   resolution: "base-x@npm:3.0.9"
   dependencies:
@@ -9209,6 +9495,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 63ae9933be5a2b8d4509daca5124e20c14d023c820258e484e32dc324d34c2754e71297c94a05784064ad27615037ef677e3f0c00469fb55f409d2bb21261035
+  languageName: node
+  linkType: hard
+
 "cookie-signature@npm:1.0.6":
   version: 1.0.6
   resolution: "cookie-signature@npm:1.0.6"
@@ -10264,6 +10557,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"diff-sequences@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "diff-sequences@npm:29.3.1"
+  checksum: 8edab8c383355022e470779a099852d595dd856f9f5bd7af24f177e74138a668932268b4c4fd54096eed643861575c3652d4ecbbb1a9d710488286aed3ffa443
+  languageName: node
+  linkType: hard
+
 "diff@npm:^4.0.1":
   version: 4.0.2
   resolution: "diff@npm:4.0.2"
@@ -10601,6 +10901,13 @@ __metadata:
   version: 0.10.2
   resolution: "emittery@npm:0.10.2"
   checksum: ee3e21788b043b90885b18ea756ec3105c1cedc50b29709c92b01e239c7e55345d4bb6d3aef4ddbaf528eef448a40b3bb831bad9ee0fc9c25cbf1367ab1ab5ac
+  languageName: node
+  linkType: hard
+
+"emittery@npm:^0.13.1":
+  version: 0.13.1
+  resolution: "emittery@npm:0.13.1"
+  checksum: 2b089ab6306f38feaabf4f6f02792f9ec85fc054fda79f44f6790e61bbf6bc4e1616afb9b232e0c5ec5289a8a452f79bfa6d905a6fd64e94b49981f0934001c6
   languageName: node
   linkType: hard
 
@@ -11412,6 +11719,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expect@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "expect@npm:29.3.1"
+  dependencies:
+    "@jest/expect-utils": ^29.3.1
+    jest-get-type: ^29.2.0
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
+  checksum: e9588c2a430b558b9a3dc72d4ad05f36b047cb477bc6a7bb9cfeef7614fe7e5edbab424c2c0ce82739ee21ecbbbd24596259528209f84cd72500cc612d910d30
+  languageName: node
+  linkType: hard
+
 "expo-application@npm:~4.2.2":
   version: 4.2.2
   resolution: "expo-application@npm:4.2.2"
@@ -11938,7 +12258,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0":
+"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -14667,6 +14987,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-changed-files@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-changed-files@npm:29.2.0"
+  dependencies:
+    execa: ^5.0.0
+    p-limit: ^3.1.0
+  checksum: 8ad8290324db1de2ee3c9443d3e3fbfdcb6d72ec7054c5796be2854b2bc239dea38a7c797c8c9c2bd959f539d44305790f2f75b18f3046b04317ed77c7480cb1
+  languageName: node
+  linkType: hard
+
 "jest-circus@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-circus@npm:27.5.1"
@@ -14721,6 +15051,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-circus@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-circus@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/expect": ^29.3.1
+    "@jest/test-result": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    co: ^4.6.0
+    dedent: ^0.7.0
+    is-generator-fn: ^2.0.0
+    jest-each: ^29.3.1
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-runtime: ^29.3.1
+    jest-snapshot: ^29.3.1
+    jest-util: ^29.3.1
+    p-limit: ^3.1.0
+    pretty-format: ^29.3.1
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 125710debd998ad9693893e7c1235e271b79f104033b8169d82afe0bc0d883f8f5245feef87adcbb22ad27ff749fd001aa998d11a132774b03b4e2b8af77d5d8
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-cli@npm:27.5.1"
@@ -14772,6 +15129,33 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: fb424576bf38346318daddee3fcc597cd78cb8dda1759d09c529d8ba1a748f2765c17b00671072a838826e59465a810ff8a232bc6ba2395c131bf3504425a363
+  languageName: node
+  linkType: hard
+
+"jest-cli@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-cli@npm:29.3.1"
+  dependencies:
+    "@jest/core": ^29.3.1
+    "@jest/test-result": ^29.3.1
+    "@jest/types": ^29.3.1
+    chalk: ^4.0.0
+    exit: ^0.1.2
+    graceful-fs: ^4.2.9
+    import-local: ^3.0.2
+    jest-config: ^29.3.1
+    jest-util: ^29.3.1
+    jest-validate: ^29.3.1
+    prompts: ^2.0.1
+    yargs: ^17.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 829895d33060042443bd1e9e87eb68993773d74f2c8a9b863acf53cece39d227ae0e7d76df2e9c5934c414bdf70ce398a34b3122cfe22164acb2499a74d7288d
   languageName: node
   linkType: hard
 
@@ -14850,6 +15234,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-config@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-config@npm:29.3.1"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@jest/test-sequencer": ^29.3.1
+    "@jest/types": ^29.3.1
+    babel-jest: ^29.3.1
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    deepmerge: ^4.2.2
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-circus: ^29.3.1
+    jest-environment-node: ^29.3.1
+    jest-get-type: ^29.2.0
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.3.1
+    jest-runner: ^29.3.1
+    jest-util: ^29.3.1
+    jest-validate: ^29.3.1
+    micromatch: ^4.0.4
+    parse-json: ^5.2.0
+    pretty-format: ^29.3.1
+    slash: ^3.0.0
+    strip-json-comments: ^3.1.1
+  peerDependencies:
+    "@types/node": "*"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 6e663f04ae1024a53a4c2c744499b4408ca9a8b74381dd5e31b11bb3c7393311ecff0fb61b06287768709eb2c9e5a2fd166d258f5a9123abbb4c5812f99c12fe
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-diff@npm:27.5.1"
@@ -14886,6 +15308,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-diff@npm:29.3.1"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^29.3.1
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.3.1
+  checksum: ac5c09745f2b1897e6f53216acaf6ed44fc4faed8e8df053ff4ac3db5d2a1d06a17b876e49faaa15c8a7a26f5671bcbed0a93781dcc2835f781c79a716a591a9
+  languageName: node
+  linkType: hard
+
 "jest-docblock@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-docblock@npm:27.5.1"
@@ -14901,6 +15335,15 @@ __metadata:
   dependencies:
     detect-newline: ^3.0.0
   checksum: 22fca68d988ecb2933bc65f448facdca85fc71b4bd0a188ea09a5ae1b0cc3a049a2a6ec7e7eaa2542c1d5cb5e5145e420a3df4fa280f5070f486c44da1d36151
+  languageName: node
+  linkType: hard
+
+"jest-docblock@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-docblock@npm:29.2.0"
+  dependencies:
+    detect-newline: ^3.0.0
+  checksum: b3f1227b7d73fc9e4952180303475cf337b36fa65c7f730ac92f0580f1c08439983262fee21cf3dba11429aa251b4eee1e3bc74796c5777116b400d78f9d2bbe
   languageName: node
   linkType: hard
 
@@ -14927,6 +15370,19 @@ __metadata:
     jest-util: ^28.1.3
     pretty-format: ^28.1.3
   checksum: 5c5b8ccb1484e58b027bea682cfa020a45e5bf5379cc7c23bdec972576c1dc3c3bf03df2b78416cefc1a58859dd33b7cf5fff54c370bc3c0f14a3e509eb87282
+  languageName: node
+  linkType: hard
+
+"jest-each@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-each@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    chalk: ^4.0.0
+    jest-get-type: ^29.2.0
+    jest-util: ^29.3.1
+    pretty-format: ^29.3.1
+  checksum: 16d51ef8f96fba44a3479f1c6f7672027e3b39236dc4e41217c38fe60a3b66b022ffcee72f8835a442f7a8a0a65980a93fb8e73a9782d192452526e442ad049a
   languageName: node
   linkType: hard
 
@@ -14970,6 +15426,20 @@ __metadata:
     jest-mock: ^28.1.3
     jest-util: ^28.1.3
   checksum: 1048fe306a6a8b0880a4c66278ebb57479f29c12cff89aab3aa79ab77a8859cf17ab8aa9919fd21c329a7db90e35581b43664e694ad453d5b04e00f3c6420469
+  languageName: node
+  linkType: hard
+
+"jest-environment-node@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-environment-node@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/fake-timers": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    jest-mock: ^29.3.1
+    jest-util: ^29.3.1
+  checksum: 16d4854bd2d35501bd4862ca069baf27ce9f5fd7642fdcab9d2dab49acd28c082d0c8882bf2bb28ed7bbaada486da577c814c9688ddc62d1d9f74a954fde996a
   languageName: node
   linkType: hard
 
@@ -15092,6 +15562,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-haste-map@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-haste-map@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@types/graceful-fs": ^4.1.3
+    "@types/node": "*"
+    anymatch: ^3.0.3
+    fb-watchman: ^2.0.0
+    fsevents: ^2.3.2
+    graceful-fs: ^4.2.9
+    jest-regex-util: ^29.2.0
+    jest-util: ^29.3.1
+    jest-worker: ^29.3.1
+    micromatch: ^4.0.4
+    walker: ^1.0.8
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  checksum: 97ea26af0c28a2ba568c9c65d06211487bbcd501cb4944f9d55e07fd2b00ad96653ea2cc9033f3d5b7dc1feda33e47ae9cc56b400191ea4533be213c9f82e67c
+  languageName: node
+  linkType: hard
+
 "jest-jasmine2@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-jasmine2@npm:27.5.1"
@@ -15137,6 +15630,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-leak-detector@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-leak-detector@npm:29.3.1"
+  dependencies:
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.3.1
+  checksum: 0dd8ed31ae0b5a3d14f13f567ca8567f2663dd2d540d1e55511d3b3fd7f80a1d075392179674ebe9fab9be0b73678bf4d2f8bbbc0f4bdd52b9815259194da559
+  languageName: node
+  linkType: hard
+
 "jest-matcher-utils@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-matcher-utils@npm:27.5.1"
@@ -15170,6 +15673,18 @@ __metadata:
     jest-get-type: ^29.2.0
     pretty-format: ^29.2.1
   checksum: d2a2f1ca8389e6ee529dc160786d912dec6cadfb395139fa1afa0f2e175775c7cf50dfe00981baae71ee0cbcab0d7f9f2d9cf9b9665dcda1d2cc04294fbd9979
+  languageName: node
+  linkType: hard
+
+"jest-matcher-utils@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-matcher-utils@npm:29.3.1"
+  dependencies:
+    chalk: ^4.0.0
+    jest-diff: ^29.3.1
+    jest-get-type: ^29.2.0
+    pretty-format: ^29.3.1
+  checksum: 311e8d9f1e935216afc7dd8c6acf1fbda67a7415e1afb1bf72757213dfb025c1f2dc5e2c185c08064a35cdc1f2d8e40c57616666774ed1b03e57eb311c20ec77
   languageName: node
   linkType: hard
 
@@ -15224,6 +15739,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-message-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-message-util@npm:29.3.1"
+  dependencies:
+    "@babel/code-frame": ^7.12.13
+    "@jest/types": ^29.3.1
+    "@types/stack-utils": ^2.0.0
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    micromatch: ^4.0.4
+    pretty-format: ^29.3.1
+    slash: ^3.0.0
+    stack-utils: ^2.0.3
+  checksum: 15d0a2fca3919eb4570bbf575734780c4b9e22de6aae903c4531b346699f7deba834c6c86fe6e9a83ad17fac0f7935511cf16dce4d71a93a71ebb25f18a6e07b
+  languageName: node
+  linkType: hard
+
 "jest-mock@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-mock@npm:27.5.1"
@@ -15241,6 +15773,17 @@ __metadata:
     "@jest/types": ^28.1.3
     "@types/node": "*"
   checksum: a573bf8e5f12f4c29c661266c31b5c6b69a28d3195b83049983bce025b2b1a0152351567e89e63b102ef817034c2a3aa97eda4e776f3bae2aee54c5765573aa7
+  languageName: node
+  linkType: hard
+
+"jest-mock@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-mock@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    jest-util: ^29.3.1
+  checksum: 9098852cb2866db4a1a59f9f7581741dfc572f648e9e574a1b187fd69f5f2f6190ad387ede21e139a8b80a6a1343ecc3d6751cd2ae1ae11d7ea9fa1950390fb2
   languageName: node
   linkType: hard
 
@@ -15277,6 +15820,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-regex-util@npm:^29.2.0":
+  version: 29.2.0
+  resolution: "jest-regex-util@npm:29.2.0"
+  checksum: 7c533e51c51230dac20c0d7395b19b8366cb022f7c6e08e6bcf2921626840ff90424af4c9b4689f02f0addfc9b071c4cd5f8f7a989298a4c8e0f9c94418ca1c3
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-resolve-dependencies@npm:27.5.1"
@@ -15295,6 +15845,16 @@ __metadata:
     jest-regex-util: ^28.0.2
     jest-snapshot: ^28.1.3
   checksum: 4eea9ec33aefc1c71dc5956391efbcc7be76bda986b366ab3931d99c5f7ed01c9ebd7520e405ea2c76e1bb2c7ce504be6eca2b9831df16564d1e625500f3bfe7
+  languageName: node
+  linkType: hard
+
+"jest-resolve-dependencies@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-resolve-dependencies@npm:29.3.1"
+  dependencies:
+    jest-regex-util: ^29.2.0
+    jest-snapshot: ^29.3.1
+  checksum: 6ec4727a87c6e7954e93de9949ab9967b340ee2f07626144c273355f05a2b65fa47eb8dece2d6e5f4fd99cdb893510a3540aa5e14ba443f70b3feb63f6f98982
   languageName: node
   linkType: hard
 
@@ -15330,6 +15890,23 @@ __metadata:
     resolve.exports: ^1.1.0
     slash: ^3.0.0
   checksum: df61a490c93f4f4cf52135e43d6a4fcacb07b0b7d4acc6319e9289529c1d14f2d8e1638e095dbf96f156834802755e38db68caca69dba21a3261ee711d4426b6
+  languageName: node
+  linkType: hard
+
+"jest-resolve@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-resolve@npm:29.3.1"
+  dependencies:
+    chalk: ^4.0.0
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.3.1
+    jest-pnp-resolver: ^1.2.2
+    jest-util: ^29.3.1
+    jest-validate: ^29.3.1
+    resolve: ^1.20.0
+    resolve.exports: ^1.1.0
+    slash: ^3.0.0
+  checksum: 0dea22ed625e07b8bfee52dea1391d3a4b453c1a0c627a0fa7c22e44bb48e1c289afe6f3c316def70753773f099c4e8f436c7a2cc12fcc6c7dd6da38cba2cd5f
   languageName: node
   linkType: hard
 
@@ -15391,6 +15968,35 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-runner@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-runner@npm:29.3.1"
+  dependencies:
+    "@jest/console": ^29.3.1
+    "@jest/environment": ^29.3.1
+    "@jest/test-result": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    emittery: ^0.13.1
+    graceful-fs: ^4.2.9
+    jest-docblock: ^29.2.0
+    jest-environment-node: ^29.3.1
+    jest-haste-map: ^29.3.1
+    jest-leak-detector: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-resolve: ^29.3.1
+    jest-runtime: ^29.3.1
+    jest-util: ^29.3.1
+    jest-watcher: ^29.3.1
+    jest-worker: ^29.3.1
+    p-limit: ^3.1.0
+    source-map-support: 0.5.13
+  checksum: 61ad445d8a5f29573332f27a21fc942fb0d2a82bf901a0ea1035bf3bd7f349d1e425f71f54c3a3f89b292a54872c3248d395a2829d987f26b6025b15530ea5d2
+  languageName: node
+  linkType: hard
+
 "jest-runtime@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-runtime@npm:27.5.1"
@@ -15448,6 +16054,36 @@ __metadata:
     slash: ^3.0.0
     strip-bom: ^4.0.0
   checksum: b17c40af858e74dafa4f515ef3711c1e9ef3d4ad7d74534ee0745422534bc04fd166d4eceb62a3aa7dc951505d6f6d2a81d16e90bebb032be409ec0500974a36
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-runtime@npm:29.3.1"
+  dependencies:
+    "@jest/environment": ^29.3.1
+    "@jest/fake-timers": ^29.3.1
+    "@jest/globals": ^29.3.1
+    "@jest/source-map": ^29.2.0
+    "@jest/test-result": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    cjs-module-lexer: ^1.0.0
+    collect-v8-coverage: ^1.0.0
+    glob: ^7.1.3
+    graceful-fs: ^4.2.9
+    jest-haste-map: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-mock: ^29.3.1
+    jest-regex-util: ^29.2.0
+    jest-resolve: ^29.3.1
+    jest-snapshot: ^29.3.1
+    jest-util: ^29.3.1
+    slash: ^3.0.0
+    strip-bom: ^4.0.0
+  checksum: 82f27b48f000be074064a854e16e768f9453e9b791d8c5f9316606c37f871b5b10f70544c1b218ab9784f00bd972bb77f868c5ab6752c275be2cd219c351f5a7
   languageName: node
   linkType: hard
 
@@ -15532,6 +16168,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-snapshot@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-snapshot@npm:29.3.1"
+  dependencies:
+    "@babel/core": ^7.11.6
+    "@babel/generator": ^7.7.2
+    "@babel/plugin-syntax-jsx": ^7.7.2
+    "@babel/plugin-syntax-typescript": ^7.7.2
+    "@babel/traverse": ^7.7.2
+    "@babel/types": ^7.3.3
+    "@jest/expect-utils": ^29.3.1
+    "@jest/transform": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/babel__traverse": ^7.0.6
+    "@types/prettier": ^2.1.5
+    babel-preset-current-node-syntax: ^1.0.0
+    chalk: ^4.0.0
+    expect: ^29.3.1
+    graceful-fs: ^4.2.9
+    jest-diff: ^29.3.1
+    jest-get-type: ^29.2.0
+    jest-haste-map: ^29.3.1
+    jest-matcher-utils: ^29.3.1
+    jest-message-util: ^29.3.1
+    jest-util: ^29.3.1
+    natural-compare: ^1.4.0
+    pretty-format: ^29.3.1
+    semver: ^7.3.5
+  checksum: d7d0077935e78c353c828be78ccb092e12ba7622cb0577f21641fadd728ae63a7c1f4a0d8113bfb38db3453a64bfa232fb1cdeefe0e2b48c52ef4065b0ab75ae
+  languageName: node
+  linkType: hard
+
 "jest-sonar-reporter@npm:^2.0.0":
   version: 2.0.0
   resolution: "jest-sonar-reporter@npm:2.0.0"
@@ -15580,6 +16248,20 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: fd6459742c941f070223f25e38a2ac0719aad92561591e9fb2a50d602a5d19d754750b79b4074327a42b00055662b95da3b006542ceb8b54309da44d4a62e721
+  languageName: node
+  linkType: hard
+
+"jest-util@npm:^29.0.0, jest-util@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-util@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    chalk: ^4.0.0
+    ci-info: ^3.2.0
+    graceful-fs: ^4.2.9
+    picomatch: ^2.2.3
+  checksum: f67c60f062b94d21cb60e84b3b812d64b7bfa81fe980151de5c17a74eb666042d0134e2e756d099b7606a1fcf1d633824d2e58197d01d76dde1e2dc00dfcd413
   languageName: node
   linkType: hard
 
@@ -15636,6 +16318,20 @@ __metadata:
     leven: ^3.1.0
     pretty-format: ^28.1.3
   checksum: 95e0513b3803c3372a145cda86edbdb33d9dfeaa18818176f2d581e821548ceac9a179f065b6d4671a941de211354efd67f1fff8789a4fb89962565c85f646db
+  languageName: node
+  linkType: hard
+
+"jest-validate@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-validate@npm:29.3.1"
+  dependencies:
+    "@jest/types": ^29.3.1
+    camelcase: ^6.2.0
+    chalk: ^4.0.0
+    jest-get-type: ^29.2.0
+    leven: ^3.1.0
+    pretty-format: ^29.3.1
+  checksum: 92584f0b8ac284235f12b3b812ccbc43ef6dea080a3b98b1aa81adbe009e962d0aa6131f21c8157b30ac3d58f335961694238a93d553d1d1e02ab264c923778c
   languageName: node
   linkType: hard
 
@@ -15698,6 +16394,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-watcher@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-watcher@npm:29.3.1"
+  dependencies:
+    "@jest/test-result": ^29.3.1
+    "@jest/types": ^29.3.1
+    "@types/node": "*"
+    ansi-escapes: ^4.2.1
+    chalk: ^4.0.0
+    emittery: ^0.13.1
+    jest-util: ^29.3.1
+    string-length: ^4.0.1
+  checksum: 60d189473486c73e9d540406a30189da5a3c67bfb0fb4ad4a83991c189135ef76d929ec99284ca5a505fe4ee9349ae3c99b54d2e00363e72837b46e77dec9642
+  languageName: node
+  linkType: hard
+
 "jest-worker@npm:^26.2.1, jest-worker@npm:^26.6.2":
   version: 26.6.2
   resolution: "jest-worker@npm:26.6.2"
@@ -15728,6 +16440,18 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: e921c9a1b8f0909da9ea07dbf3592f95b653aef3a8bb0cbcd20fc7f9a795a1304adecac31eecb308992c167e8d7e75c522061fec38a5928ace0f9571c90169ca
+  languageName: node
+  linkType: hard
+
+"jest-worker@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest-worker@npm:29.3.1"
+  dependencies:
+    "@types/node": "*"
+    jest-util: ^29.3.1
+    merge-stream: ^2.0.0
+    supports-color: ^8.0.0
+  checksum: 38687fcbdc2b7ddc70bbb5dfc703ae095b46b3c7f206d62ecdf5f4d16e336178e217302138f3b906125576bb1cfe4cfe8d43681276fa5899d138ed9422099fb3
   languageName: node
   linkType: hard
 
@@ -15765,6 +16489,25 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: b9dcb542eb7c16261c281cdc2bf37155dbb3f1205bae0b567f05051db362c85ddd4b765f126591efb88f6d298eb10336d0aa6c7d5373b4d53f918137a9a70182
+  languageName: node
+  linkType: hard
+
+"jest@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "jest@npm:29.3.1"
+  dependencies:
+    "@jest/core": ^29.3.1
+    "@jest/types": ^29.3.1
+    import-local: ^3.0.2
+    jest-cli: ^29.3.1
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: bin/jest.js
+  checksum: 613f4ec657b14dd84c0056b2fef1468502927fd551bef0b19d4a91576a609678fb316c6a5b5fc6120dd30dd4ff4569070ffef3cb507db9bb0260b28ddaa18d7a
   languageName: node
   linkType: hard
 
@@ -16146,6 +16889,13 @@ __metadata:
     json-schema: 0.4.0
     verror: 1.10.0
   checksum: 2ad1b9fdcccae8b3d580fa6ced25de930eaa1ad154db21bbf8478a4d30bbbec7925b5f5ff29b933fba9412b16a17bd484a8da4fdb3663b5e27af95dd693bab2a
+  languageName: node
+  linkType: hard
+
+"jssha@npm:2.3.1":
+  version: 2.3.1
+  resolution: "jssha@npm:2.3.1"
+  checksum: 3c0daa0b570b171592a3ed49496e6ec41d305eeed97279bbee0f0e537f77afc0371fd842cdaae6acc5d3c0aaf5ab7785e298330119576c2c634c2334d871b50c
   languageName: node
   linkType: hard
 
@@ -19880,6 +20630,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pretty-format@npm:^29.3.1":
+  version: 29.3.1
+  resolution: "pretty-format@npm:29.3.1"
+  dependencies:
+    "@jest/schemas": ^29.0.0
+    ansi-styles: ^5.0.0
+    react-is: ^18.0.0
+  checksum: 9917a0bb859cd7a24a343363f70d5222402c86d10eb45bcc2f77b23a4e67586257390e959061aec22762a782fe6bafb59bf34eb94527bc2e5d211afdb287eb4e
+  languageName: node
+  linkType: hard
+
 "process-nextick-args@npm:~2.0.0":
   version: 2.0.1
   resolution: "process-nextick-args@npm:2.0.1"
@@ -23263,6 +24024,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-jest@npm:^29.0.3":
+  version: 29.0.3
+  resolution: "ts-jest@npm:29.0.3"
+  dependencies:
+    bs-logger: 0.x
+    fast-json-stable-stringify: 2.x
+    jest-util: ^29.0.0
+    json5: ^2.2.1
+    lodash.memoize: 4.x
+    make-error: 1.x
+    semver: 7.x
+    yargs-parser: ^21.0.1
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 541e51776d367fa2279af47f75af94b03e0538f1839ea9983de0f4ad7f188002f6eb1fc72440651d96daa62d25a7bc679a129c14e6ef291277eea9346751d56b
+  languageName: node
+  linkType: hard
+
 "ts-loader@npm:^9.3.1":
   version: 9.4.1
   resolution: "ts-loader@npm:9.4.1"
@@ -24257,6 +25051,16 @@ __metadata:
   dependencies:
     makeerror: 1.0.12
   checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
+  languageName: node
+  linkType: hard
+
+"wallet-address-validator@npm:^0.2.4":
+  version: 0.2.4
+  resolution: "wallet-address-validator@npm:0.2.4"
+  dependencies:
+    base-x: ^3.0.4
+    jssha: 2.3.1
+  checksum: 490ab99dc08a69d6a703cb67feb23a67b08b0f8869b069d0440dd34493ec49d79a48d09079550d55d1106f9ece4dde09bd1425a07524b46eae6c1b954c0b5fde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-120

## Changes
- Create formal function that can parse eth and btc wallets but also transaction hashes
- Use new function to clean up a bunch of code that used improper ways of figuring out the currency type from an address