### PR TITLE
CRYP-226: fix transaction in and out flipped

### DIFF
--- a/packages/btc-edge/src/types/so_chain_responses.ts
+++ b/packages/btc-edge/src/types/so_chain_responses.ts
@@ -73,3 +73,5 @@ export interface TransactionResponseOutput {
     script_asm: string;
     script_hex: string;
 }
+
+export type PairsWithAmount = (readonly [TransactionResponseInput, TransactionResponseOutput, string])[];

--- a/packages/btc-edge/test/unit/gateways/so_chain_gateway.spec.ts
+++ b/packages/btc-edge/test/unit/gateways/so_chain_gateway.spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { SoChainGateway } from "@cryptify/btc-edge/src/gateways/so_chain_gateway";
+import { ConfigService } from "@nestjs/config";
+import { Repository } from "typeorm";
+import { Transaction } from "@cryptify/common/src/domain/entities/transaction";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { PairsWithAmount } from "@cryptify/btc-edge/src/types/so_chain_responses";
+
+describe("SoChainGateway", () => {
+    let soChainGateway: SoChainGateway;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                SoChainGateway,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: () => "",
+                    },
+                },
+                {
+                    provide: getRepositoryToken(Transaction),
+                    useClass: Repository,
+                },
+            ],
+        }).compile();
+
+        soChainGateway = module.get<SoChainGateway>(SoChainGateway);
+    });
+
+    describe("SoChainGateway::reversePoolMIMOTransaction", () => {
+        it("should return correct pairs with amounts", () => {
+            const inputs = [
+                {
+                    address: "ad1",
+                    value: ".501",
+                },
+                {
+                    address: "ad2",
+                    value: "1.2",
+                },
+            ] as any;
+            const outputs = [
+                {
+                    address: "ad3",
+                    value: ".7",
+                },
+                {
+                    address: "ad4",
+                    value: ".751",
+                },
+                {
+                    address: "ad5",
+                    value: ".25",
+                },
+            ] as any;
+
+            const pairsWithAmounts = (soChainGateway as any).reversePoolMIMOTransaction(
+                inputs,
+                outputs,
+            ) as PairsWithAmount;
+
+            const total = pairsWithAmounts.reduce((sum, pair) => +pair[2] + sum, 0);
+            expect(+total).toBeCloseTo(1.7, 2);
+        });
+    });
+});

--- a/packages/eth-edge/src/services/alchemy_node_facade.service.ts
+++ b/packages/eth-edge/src/services/alchemy_node_facade.service.ts
@@ -59,8 +59,8 @@ export class AlchemyNodeServiceFacade {
         return transfers.map((transfer) => ({
             id: -1,
             transactionAddress: transfer.hash,
-            walletIn: transfer.from,
-            walletOut: transfer.to,
+            walletIn: transfer.to,
+            walletOut: transfer.from,
             amount: Web3.utils.toWei(normalizeCurrency(transfer.value), "ether"),
             createdAt: new Date(transfer.metadata.blockTimestamp),
         }));


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-226

## Changes
- Fix ETH transactions being stored backwards
- Fix BTC transactions being stored backwards
- Implement BTC reverse transaction pooling to improve accuracy of MIMO transaction amounts