### PR TITLE
CRYP-162: bitcoin transaction details page

### DIFF
--- a/packages/client/components/TransactionDetails.tsx
+++ b/packages/client/components/TransactionDetails.tsx
@@ -57,7 +57,6 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                 <Box>
                     <Text size={"subheadline"} color="text.500">
                         Transaction ID
-                        
                     </Text>
                     <HStack space="10px">
                         <Text style={styles.elementInformationText}>{transaction.transactionAddress}</Text>
@@ -76,7 +75,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Badge>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? styles.subItemWrapper : {display: "none"}}>
+                <Box style={currencyTypeCheck ? styles.subItemWrapper : { display: "none" }}>
                     <Text size={"subheadline"} color="text.500">
                         Fee
                     </Text>
@@ -135,7 +134,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Text>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? {display: "none"} : styles.subItemWrapper}>
+                <Box style={currencyTypeCheck ? { display: "none" } : styles.subItemWrapper}>
                     <HStack>
                         <Text style={styles.elementInformationText}>Position in Block</Text>
                         <Text color="text.500" style={styles.gasLimit}>
@@ -143,7 +142,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Text>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? {display: "none"} : styles.subItemWrapper}>
+                <Box style={currencyTypeCheck ? { display: "none" } : styles.subItemWrapper}>
                     <HStack>
                         <Text style={styles.elementInformationText}>Nonce</Text>
                         <Text color="text.500" style={styles.gasLimit}>
@@ -151,7 +150,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Text>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? {display: "none"} : styles.subItemWrapper}>
+                <Box style={currencyTypeCheck ? { display: "none" } : styles.subItemWrapper}>
                     <HStack>
                         <Text style={styles.elementInformationText}>Gas Limit (Units)</Text>
                         <Text color="text.500" style={styles.gasLimit}>
@@ -159,7 +158,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Text>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? styles.subItemWrapper : {display: "none"} }>
+                <Box style={currencyTypeCheck ? styles.subItemWrapper : { display: "none" }}>
                     <HStack>
                         <Text style={styles.elementInformationText}>Confirmations</Text>
                         <Text color="text.500" style={styles.gasLimit}>
@@ -167,7 +166,7 @@ export function TransactionDetails({ transaction, walletAddress }: Props) {
                         </Text>
                     </HStack>
                 </Box>
-                <Box style={currencyTypeCheck ? {display: "none"} : styles.subItemWrapper}>
+                <Box style={currencyTypeCheck ? { display: "none" } : styles.subItemWrapper}>
                     <Text size={"subheadline"} color="text.500">
                         Gas Price
                     </Text>

--- a/packages/client/screens/WalletOverviewScreen.tsx
+++ b/packages/client/screens/WalletOverviewScreen.tsx
@@ -42,7 +42,10 @@ export default function WalletOverviewScreen({ route, navigation }: Props) {
     }, []);
     return (
         <View style={styles.view}>
-            <Box style={styles.walletDetailsWrapper} backgroundColor = {currencyType == "BITCOIN" ? "rgba(247, 147, 26, 0.25)":"rgba(60, 60, 61, 0.25)"}>
+            <Box
+                style={styles.walletDetailsWrapper}
+                backgroundColor={currencyType == "BITCOIN" ? "rgba(247, 147, 26, 0.25)" : "rgba(60, 60, 61, 0.25)"}
+            >
                 <VStack style={styles.walletDetails}>
                     <HStack justifyContent="space-between">
                         <VStack>
@@ -53,7 +56,11 @@ export default function WalletOverviewScreen({ route, navigation }: Props) {
                             </Text>
                         </VStack>
                         <VStack>
-                            <FontAwesomeIcon icon={currencyIcon} color = {currencyType == "BITCOIN" ? "#F7931A":"#3C3C3D "} size={40} />
+                            <FontAwesomeIcon
+                                icon={currencyIcon}
+                                color={currencyType == "BITCOIN" ? "#F7931A" : "#3C3C3D"}
+                                size={40}
+                            />
                         </VStack>
                     </HStack>
                     <HStack alignItems="center">


### PR DESCRIPTION
Added BTC styling to the wallet overview page and transactions details page

![image](https://user-images.githubusercontent.com/68691272/206872178-b83e9a96-2956-4531-bf46-a97b53ee6ca8.png)
![image](https://user-images.githubusercontent.com/68691272/206872188-b4d1fb89-6218-40c9-8663-846c8c59d234.png)
