### PR TITLE
CRYP-41: Fix styling on notifications page

### DIFF
--- a/packages/client/screens/NotificationsScreen.tsx
+++ b/packages/client/screens/NotificationsScreen.tsx
@@ -29,10 +29,10 @@ export default function NotificationsScreen() {
 
     return (
         <View style={styles.view}>
-            <HStack alignItems={"center"} space={"lg"}>
+            <HStack alignItems="center">
                 <FontAwesomeIcon icon={falArrowRightArrowLeft} size={26} />
-                <VStack>
-                    <Text>Trasactions</Text>
+                <VStack ml={15} flex={1}>
+                    <Text>Transactions</Text>
                     <Text color="text.500" size={"footnote1"}>
                         Send and receive transactions for all wallets
                     </Text>
@@ -42,6 +42,7 @@ export default function NotificationsScreen() {
                     thumbColor={"#FFFFFF"}
                     onValueChange={toggleSwitch}
                     value={isEnabled}
+                    style={{ marginLeft: "auto" }}
                 />
             </HStack>
         </View>


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-41

## Changes
- Fix typo
- Fix spacing on android
- Fix text spacing on all devices

## Dev note
- On Android the switch is smaller than the one on iOS but they take the same footprint so on Android the button is pushed to the left 10-15px more than on iOS, fixing this on Android would then make the iOS version look too far to the right. I've opted to just leave it as is for now, we can write some custom Android css rule to fix it if needed in the future.

## Screenshots
![Screenshot_1673383616](https://user-images.githubusercontent.com/19786843/211659295-48cc9c34-2705-412c-8010-90b8ed54d19b.png)
