### PR TITLE
CRYP-240: Fix incorrect back arrow button displayed on iOS devices

### DIFF
--- a/packages/client/components/BackButton.tsx
+++ b/packages/client/components/BackButton.tsx
@@ -1,0 +1,14 @@
+import { Pressable } from "native-base";
+import React from "react";
+import { farArrowLeft } from "./icons/regular/farArrowLeft";
+import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
+
+export default function BackButton(navigation: any) {
+    return (
+        <>
+            <Pressable onPress={() => navigation.goBack()}>
+                <FontAwesomeIcon icon={farArrowLeft} size={20} />
+            </Pressable>
+        </>
+    );
+}

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -45,12 +45,12 @@ import FilterScreen from "../screens/FilterScreen";
 import EditTagScreen from "../screens/EditTagScreen";
 import TransactionTagsScreen from "../screens/TransactionTagsScreen";
 import AddTransactionTagsScreen from "../screens/AddTransactionTagsScreen";
-import { farArrowLeft } from "../components/icons/regular/farArrowLeft";
 import NotificationsScreen from "../screens/NotificationsScreen";
 import SignUpNotificationsScreen from "../screens/SignUpNotificationsScreen";
 import useTabBar from "../hooks/useTabBar";
 import ContactsListScreen from "../screens/ContactsListScreen";
 import AddContactScreen from "../screens/AddContactScreen";
+import BackButton from "../components/BackButton";
 
 // TODO refactor this file to reduce code duplication and see if
 // there is a way to centralize some of the styling between
@@ -62,7 +62,11 @@ function HomeStackScreen({ navigation, route }: { route: RouteProp<any, any>; na
     useTabBar({ navigation, route, initialScreenName: "HomeScreen" });
 
     return (
-        <HomeStack.Navigator>
+        <HomeStack.Navigator
+            screenOptions={({ navigation }) => ({
+                headerLeft: () => BackButton(navigation),
+            })}
+        >
             <HomeStack.Screen
                 name="HomeScreen"
                 component={HomeScreen}
@@ -74,6 +78,7 @@ function HomeStackScreen({ navigation, route }: { route: RouteProp<any, any>; na
                         fontWeight: "600",
                     },
                     headerShadowVisible: false,
+                    headerLeft: () => null,
                 }}
             />
             <HomeStack.Screen
@@ -135,16 +140,6 @@ function HomeStackScreen({ navigation, route }: { route: RouteProp<any, any>; na
                     },
                     headerShadowVisible: false,
                     headerTitleAlign: "center",
-                    // TODO refactor to reduce code duplication and unify with other screens
-                    headerLeft: () => (
-                        <Pressable
-                            onPress={() => {
-                                navigation.goBack();
-                            }}
-                        >
-                            <FontAwesomeIcon icon={farArrowLeft} color="#404040" size={22} />
-                        </Pressable>
-                    ),
                 }}
             />
             <HomeStack.Screen
@@ -159,16 +154,6 @@ function HomeStackScreen({ navigation, route }: { route: RouteProp<any, any>; na
                     },
                     headerShadowVisible: false,
                     headerTitleAlign: "center",
-                    // TODO refactor to reduce code duplication and unify with other screens
-                    headerLeft: () => (
-                        <Pressable
-                            onPress={() => {
-                                navigation.goBack();
-                            }}
-                        >
-                            <FontAwesomeIcon icon={farArrowLeft} color="#404040" size={22} />
-                        </Pressable>
-                    ),
                 }}
             />
             <HomeStack.Screen
@@ -254,7 +239,11 @@ function SettingsStackScreen({ navigation, route }: { route: RouteProp<any, any>
     useTabBar({ navigation, route, initialScreenName: "SettingsScreen" });
 
     return (
-        <SettingsStack.Navigator>
+        <SettingsStack.Navigator
+            screenOptions={({ navigation }) => ({
+                headerLeft: () => BackButton(navigation),
+            })}
+        >
             <SettingsStack.Screen
                 name="SettingsScreen"
                 component={SettingsScreen}
@@ -266,6 +255,7 @@ function SettingsStackScreen({ navigation, route }: { route: RouteProp<any, any>
                         fontWeight: "600",
                     },
                     headerShadowVisible: false,
+                    headerLeft: () => null,
                 }}
             />
             <SettingsStack.Screen
@@ -529,11 +519,12 @@ function GuestStackScreen() {
             <GuestStack.Screen
                 name="SignInScreen"
                 component={SignInScreen}
-                options={{
+                options={({ navigation }) => ({
                     title: "",
                     headerTintColor: "#404040",
                     headerShadowVisible: false,
-                }}
+                    headerLeft: () => BackButton(navigation),
+                })}
             />
             <GuestStack.Screen
                 name="SignUpNotificationsScreen"


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-240

## Fix
- The back button in the top navigation bar on iOS devices displays the correct `arrow-left` icon without a `Back` label (as shown in the UI mockups)
- The back button is by default displayed on all screens. To hide the back button on a specific screen, put `headerLeft: () => null` in the `options` prop for the associated screen (see `<HomeStack.Screen`)

![322664512_594414345847387_8303961815300376869_n](https://user-images.githubusercontent.com/15861967/212570549-ece038ed-9c43-4ee4-8274-a2cb0f438bf3.jpg)

