### PR TITLE
CRYP-275: Fix incorrect date displayed in the header of transaction details screen

### DIFF
--- a/packages/client/components/transactions-list/TransactionListItem.tsx
+++ b/packages/client/components/transactions-list/TransactionListItem.tsx
@@ -6,9 +6,8 @@ import { Transaction } from "@cryptify/common/src/domain/entities/transaction";
 import { falCircleArrowDownLeft } from "../icons/light/falCircleArrowDownLeft";
 import { falCircleArrowUpRight } from "../icons/light/falCircleArrowUpRight";
 import { CompositeNavigationProp } from "@react-navigation/native";
-import { getFormattedAmount } from "@cryptify/common/src/utils/currency_utils";
+import { getFormattedAmount, getCurrencyType, typeToISOCode } from "@cryptify/common/src/utils/currency_utils";
 import { formatAddress } from "@cryptify/common/src/utils/address_utils";
-import { getCurrencyType, typeToISOCode } from "@cryptify/common/src/utils/currency_utils";
 
 type Props = {
     transaction: Transaction;
@@ -26,17 +25,12 @@ export function TransactionListItem({ transaction, walletAddress, navigation }: 
         return `${datePart} • ${timePart}`;
     }
 
-    function getWeekday(timestamp: string): string {
-        const date = new Date(timestamp);
-        return date.toLocaleString("en-US", { weekday: "long" });
-    }
-
     return (
         <Pressable
             testID={"transactionsListItem"}
             onPress={() =>
                 navigation.navigate("TransactionDetailsScreen", {
-                    title: getWeekday(transaction.createdAt as any),
+                    title: getFormattedDate(transaction.createdAt as any),
                     transaction: transaction,
                     walletAddress: walletAddress,
                 })


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-275

## Fix
- The header of both transaction details screen displays the correct date and time format `Mon DD, YYYY • 00:00 AM/PM` instead of `Monday`

![322036130_553693756815969_7553432608029036746_n](https://user-images.githubusercontent.com/15861967/212799959-0a9bf3d5-9756-4565-9f20-5d6f4f4d499c.jpg)
