### PR TITLE
CRYP-337: Fix settings screen title incorrectly placed on iOS devices

### DIFF
--- a/packages/client/components/SignOutButton.tsx
+++ b/packages/client/components/SignOutButton.tsx
@@ -13,7 +13,13 @@ export default function SignOutButton() {
     }
 
     return (
-        <Button variant="outline" _text={{ color: "error.500" }} onPress={handleSignOut} testID="signOutButton">
+        <Button
+            variant="outline"
+            _text={{ color: "error.500" }}
+            onPress={handleSignOut}
+            marginTop="13px"
+            testID="signOutButton"
+        >
             Sign out
         </Button>
     );

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -421,12 +421,7 @@ function SettingsStackScreen({ navigation, route }: { route: RouteProp<any, any>
                 name="SettingsScreen"
                 component={SettingsScreen}
                 options={{
-                    title: "Settings",
-                    headerTintColor: "#404040",
-                    headerTitleStyle: {
-                        fontSize: 28,
-                        fontWeight: "600",
-                    },
+                    title: "",
                     headerShadowVisible: false,
                     headerLeft: () => null,
                 }}

--- a/packages/client/screens/SettingsScreen.tsx
+++ b/packages/client/screens/SettingsScreen.tsx
@@ -54,7 +54,10 @@ export default function SettingsScreen({ navigation }: SettingsStackScreenProps<
 
     return (
         <View style={styles.view}>
-            <VStack space="7.5px">
+            <Text size={"title1"} fontWeight={"semibold"}>
+                Settings
+            </Text>
+            <VStack space="2px" marginTop="20px">
                 {items.map((item) => (
                     <Pressable
                         onPress={item.onPress}
@@ -97,6 +100,5 @@ const styles = StyleSheet.create({
     chevronRightIcon: {
         color: "#A3A3A3",
         marginLeft: "auto",
-        marginRight: 5,
     },
 });


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-337

## Fix

- Settings screen title is now correctly placed on iOS devices according to the UI mockups and no longer in the top navigation bar
- Adjusted spacing between list items

![334103623_763406601762456_2343257436216258675_n](https://user-images.githubusercontent.com/15861967/227566078-b9c0d7f9-12c4-426f-beda-6fc09e642ab7.jpg)
