### PR TITLE
CRYP-339: Fix Bitcoin balance in accordion header not properly aligned

### DIFF
--- a/packages/client/components/wallets-list/WalletsListAccordion.tsx
+++ b/packages/client/components/wallets-list/WalletsListAccordion.tsx
@@ -59,6 +59,7 @@ export function WalletsListAccordion({ wallets, showCurrencyTotals, navigation, 
                         currency={currency}
                         amount={amount}
                         fontWeight={"semibold"}
+                        amountStyles={styles.walletTotalAmount}
                         currencyCodeStyles={styles.walletTotalCurrencyCode}
                     />
                 ) : (
@@ -158,6 +159,9 @@ const styles = StyleSheet.create({
     },
     walletTotalCurrencyCode: {
         marginRight: 5,
+    },
+    walletTotalAmount: {
+        marginLeft: "auto",
     },
     bitcoinIcon: {
         color: "#F7931A",


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-339

## Fix

- Aligned the total Bitcoin balance of all wallets in the accordion header to the right

![334219623_5951977064928346_1047207563341849787_n](https://user-images.githubusercontent.com/15861967/227580043-24d4549a-5edc-4dee-b97f-17f88a072371.jpg)
