### PR TITLE
CRYP-346: Fix incorrect go back button text in add wallet success & failure screens

### DIFF
--- a/packages/client/components/TitleTextWithIcon.tsx
+++ b/packages/client/components/TitleTextWithIcon.tsx
@@ -16,7 +16,7 @@ export function TitleTextWithIcon({ icon, iconStyles, iconSize, textSize, space,
     return (
         <VStack space={`${space}px`} alignItems="center">
             <FontAwesomeIcon icon={icon} style={iconStyles} size={iconSize} />
-            <Text size={textSize} fontWeight={"semibold"}>
+            <Text size={textSize} fontWeight={"semibold"} textAlign={"center"}>
                 {children}
             </Text>
         </VStack>

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -429,7 +429,13 @@ function SettingsStackScreen({ navigation, route }: { route: RouteProp<any, any>
                     headerShadowVisible: false,
                     headerTitleAlign: "center",
                     headerRight: () => (
-                        <Pressable onPress={() => navigation.navigate("AddWalletSelectionScreen")}>
+                        <Pressable
+                            onPress={() =>
+                                navigation.navigate("AddWalletSelectionScreen", {
+                                    addWalletStartScreenName: "ViewWalletsScreen",
+                                })
+                            }
+                        >
                             <FontAwesomeIcon icon={farPlus} color="#404040" size={22} />
                         </Pressable>
                     ),

--- a/packages/client/screens/HomeScreen.tsx
+++ b/packages/client/screens/HomeScreen.tsx
@@ -24,7 +24,14 @@ export default function HomeScreen({ navigation }: HomeStackScreenProps<"HomeScr
                     <Text size={"title3"} fontWeight={"semibold"}>
                         Wallets
                     </Text>
-                    <Pressable onPress={() => navigation.navigate("AddWalletSelectionScreen")} testID="addWalletButton">
+                    <Pressable
+                        onPress={() =>
+                            navigation.navigate("AddWalletSelectionScreen", {
+                                addWalletStartScreenName: "HomeScreen",
+                            })
+                        }
+                        testID="addWalletButton"
+                    >
                         <FontAwesomeIcon icon={fasCirclePlusSolid} style={styles.addWalletIcon} size={22} />
                     </Pressable>
                 </HStack>

--- a/packages/client/screens/SignUpNotificationsScreen.tsx
+++ b/packages/client/screens/SignUpNotificationsScreen.tsx
@@ -98,6 +98,6 @@ const styles = StyleSheet.create({
         paddingHorizontal: 15,
     },
     bellIcon: {
-        marginTop: 80,
+        marginTop: 60,
     },
 });

--- a/packages/client/screens/WalletSettingsScreen.tsx
+++ b/packages/client/screens/WalletSettingsScreen.tsx
@@ -146,8 +146,7 @@ export default function WalletSettingsScreen({ navigation, route }: SettingsStac
 const styles = StyleSheet.create({
     view: {
         flex: 1,
-        paddingLeft: 15,
-        paddingRight: 15,
+        paddingHorizontal: 15,
         paddingTop: 20,
     },
 });

--- a/packages/client/screens/add-wallet/AddWalletScreen.tsx
+++ b/packages/client/screens/add-wallet/AddWalletScreen.tsx
@@ -64,6 +64,7 @@ export default function AddWalletScreen({ route, navigation }: Props) {
                 currencyType={currencyType}
                 setState={setState}
                 walletName={walletName}
+                addWalletStartScreenName={addWalletStartScreenName}
                 navigation={navigation}
             />
         );

--- a/packages/client/screens/add-wallet/AddWalletScreen.tsx
+++ b/packages/client/screens/add-wallet/AddWalletScreen.tsx
@@ -13,7 +13,7 @@ import { FormikErrors } from "formik";
 type Props = CompositeScreenProps<HomeStackScreenProps<"AddWalletScreen">, SettingsStackScreenProps<"AddWalletScreen">>;
 
 export default function AddWalletScreen({ route, navigation }: Props) {
-    const currencyType = route.params.currencyType;
+    const { currencyType, addWalletStartScreenName } = route.params;
 
     const [state, setState] = React.useState(AddWalletState.FORM);
     const [walletName, setWalletName] = React.useState<string>("");
@@ -53,6 +53,7 @@ export default function AddWalletScreen({ route, navigation }: Props) {
                 currencyType={currencyType}
                 setState={setState}
                 walletName={walletName}
+                addWalletStartScreenName={addWalletStartScreenName}
                 navigation={navigation}
             />
         );

--- a/packages/client/screens/add-wallet/AddWalletSelectionScreen.tsx
+++ b/packages/client/screens/add-wallet/AddWalletSelectionScreen.tsx
@@ -14,7 +14,7 @@ type Props = CompositeScreenProps<
     SettingsStackScreenProps<"AddWalletSelectionScreen">
 >;
 
-export default function AddWalletSelectionScreen({ navigation }: Props) {
+export default function AddWalletSelectionScreen({ route, navigation }: Props) {
     return (
         <View style={styles.view}>
             <Text size={"title1"} fontWeight={"semibold"}>
@@ -23,7 +23,12 @@ export default function AddWalletSelectionScreen({ navigation }: Props) {
             <VStack style={styles.currencyTypeStack} space="2px">
                 {currenciesDisplayData.map((currency) => (
                     <Pressable
-                        onPress={() => navigation.navigate("AddWalletScreen", { currencyType: currency.type })}
+                        onPress={() =>
+                            navigation.navigate("AddWalletScreen", {
+                                currencyType: currency.type,
+                                addWalletStartScreenName: route.params.addWalletStartScreenName,
+                            })
+                        }
                         key={currency.type}
                         style={styles.currencyTypeItem}
                         _pressed={{

--- a/packages/client/screens/add-wallet/add-wallet-states/AddWalletFailureScreen.tsx
+++ b/packages/client/screens/add-wallet/add-wallet-states/AddWalletFailureScreen.tsx
@@ -1,24 +1,31 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { titleCase } from "@cryptify/common/src/utils/string_utils";
 import { TitleTextWithIcon } from "../../../components/TitleTextWithIcon";
-import { Box, Button, Center, Link, View } from "native-base";
+import { Box, Button, Center, Link, View, VStack } from "native-base";
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 import { AddWalletState } from "./add_wallet_state";
 import { CompositeNavigationProp } from "@react-navigation/native";
 import { falCircleXMark } from "../../../components/icons/light/falCircleXMark";
+import { getCurrencyTypeUILabel } from "@cryptify/common/src/utils/currency_utils";
 
 type Props = {
     currencyType: CurrencyType;
     setState: React.Dispatch<React.SetStateAction<AddWalletState>>;
     walletName: string;
+    addWalletStartScreenName: string;
     navigation: CompositeNavigationProp<any, any>;
 };
 
-export default function AddWalletFailureScreen({ currencyType, setState, walletName, navigation }: Props) {
+export default function AddWalletFailureScreen({
+    currencyType,
+    setState,
+    walletName,
+    addWalletStartScreenName,
+    navigation,
+}: Props) {
     return (
         <View style={styles.view} backgroundColor="error.50">
-            <Box paddingTop="130px"></Box>
+            <Box paddingTop="80px"></Box>
             <TitleTextWithIcon
                 icon={falCircleXMark}
                 iconSize={96}
@@ -26,29 +33,31 @@ export default function AddWalletFailureScreen({ currencyType, setState, walletN
                 textSize={"title3"}
                 space={30}
             >
-                Could Not Add {titleCase(currencyType)} Wallet
+                Could Not Add {getCurrencyTypeUILabel(currencyType)} Wallet
                 {"\n"}
                 {walletName}
             </TitleTextWithIcon>
             <Center style={{ flex: 1 }}></Center>
-            <Button onPress={() => setState(AddWalletState.FORM)} backgroundColor={"error.500"}>
-                Try again
-            </Button>
-            <Center marginTop="20px" marginBottom="15px">
-                <Link
-                    _text={{
-                        color: "error.500",
-                        fontWeight: "semibold",
-                    }}
-                    isUnderlined={false}
-                    onPress={() => {
-                        navigation.goBack();
-                        navigation.goBack();
-                    }}
-                >
-                    Back to wallets
-                </Link>
-            </Center>
+            <VStack space={"20px"} marginBottom="20px">
+                <Button onPress={() => setState(AddWalletState.FORM)} backgroundColor={"error.500"}>
+                    Try again
+                </Button>
+                <Center>
+                    <Link
+                        _text={{
+                            color: "error.500",
+                            fontWeight: "semibold",
+                        }}
+                        isUnderlined={false}
+                        onPress={() => {
+                            navigation.goBack();
+                            navigation.goBack();
+                        }}
+                    >
+                        Back to {addWalletStartScreenName === "HomeScreen" ? "home" : "wallets"}
+                    </Link>
+                </Center>
+            </VStack>
         </View>
     );
 }

--- a/packages/client/screens/add-wallet/add-wallet-states/AddWalletSuccessScreen.tsx
+++ b/packages/client/screens/add-wallet/add-wallet-states/AddWalletSuccessScreen.tsx
@@ -1,26 +1,33 @@
 import React from "react";
 import { StyleSheet } from "react-native";
-import { titleCase } from "@cryptify/common/src/utils/string_utils";
 import { TitleTextWithIcon } from "../../../components/TitleTextWithIcon";
-import { Box, Button, Center, Link, View } from "native-base";
+import { Box, Button, Center, Link, View, VStack } from "native-base";
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 import { AddWalletState } from "./add_wallet_state";
 import { falCircleCheck } from "../../../components/icons/light/falCircleCheck";
 import { CompositeNavigationProp } from "@react-navigation/native";
+import { getCurrencyTypeUILabel } from "@cryptify/common/src/utils/currency_utils";
 
 type Props = {
     currencyType: CurrencyType;
     setState: React.Dispatch<React.SetStateAction<AddWalletState>>;
     walletName: string;
+    addWalletStartScreenName: string;
     navigation: CompositeNavigationProp<any, any>;
 };
 
-export default function AddWalletSuccessScreen({ currencyType, setState, walletName, navigation }: Props) {
-    const buttonText = `Add another ${titleCase(currencyType)} wallet`;
+export default function AddWalletSuccessScreen({
+    currencyType,
+    setState,
+    walletName,
+    addWalletStartScreenName,
+    navigation,
+}: Props) {
+    const buttonText = `Add another ${getCurrencyTypeUILabel(currencyType)} wallet`;
 
     return (
         <View style={styles.view} backgroundColor="success.50">
-            <Box paddingTop="130px"></Box>
+            <Box paddingTop="80px"></Box>
             <TitleTextWithIcon
                 icon={falCircleCheck}
                 iconSize={96}
@@ -28,30 +35,32 @@ export default function AddWalletSuccessScreen({ currencyType, setState, walletN
                 textSize={"title3"}
                 space={30}
             >
-                Added {titleCase(currencyType)} Wallet
+                Added {getCurrencyTypeUILabel(currencyType)} Wallet
                 {"\n"}
                 {walletName}
             </TitleTextWithIcon>
             <Center style={{ flex: 1 }}></Center>
-            <Button onPress={() => setState(AddWalletState.FORM)} backgroundColor={"success.500"}>
-                {buttonText}
-            </Button>
-            <Center marginTop="20px" marginBottom="15px">
-                <Link
-                    _text={{
-                        color: "success.500",
-                        fontWeight: "semibold",
-                    }}
-                    isUnderlined={false}
-                    onPress={() => {
-                        navigation.goBack();
-                        navigation.goBack();
-                    }}
-                    testID="backToWalletsButton"
-                >
-                    Back to wallets
-                </Link>
-            </Center>
+            <VStack space={"20px"} marginBottom="20px">
+                <Button onPress={() => setState(AddWalletState.FORM)} backgroundColor={"success.500"}>
+                    {buttonText}
+                </Button>
+                <Center>
+                    <Link
+                        _text={{
+                            color: "success.500",
+                            fontWeight: "semibold",
+                        }}
+                        isUnderlined={false}
+                        onPress={() => {
+                            navigation.goBack();
+                            navigation.goBack();
+                        }}
+                        testID="backToButton"
+                    >
+                        Back to {addWalletStartScreenName === "HomeScreen" ? "home" : "wallets"}
+                    </Link>
+                </Center>
+            </VStack>
         </View>
     );
 }

--- a/packages/client/tests/system/CRYP-24_add_wallet.e2e.ts
+++ b/packages/client/tests/system/CRYP-24_add_wallet.e2e.ts
@@ -33,7 +33,7 @@ describe("CRYP-24 Add wallet", () => {
         await waitFor(element(by.text("Add another Ethereum wallet")))
             .toBeVisible()
             .withTimeout(5000);
-        await element(by.id("backToWalletsButton")).tap();
+        await element(by.id("backToButton")).tap();
 
         // Assert ethereum wallets
         await element(by.id("walletsListETHEREUM")).tap();

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -27,6 +27,7 @@ declare global {
 
 type AddWalletScreenProps = {
     currencyType: CurrencyType;
+    addWalletStartScreenName: string;
 };
 
 type TransactionDetailsProps = {
@@ -149,9 +150,13 @@ export type CreateNewPasswordScreenProps = {
     token: string;
 };
 
+export type AddWalletSelectionScreenProps = {
+    addWalletStartScreenName: string;
+};
+
 export type HomeStackParamList = {
     HomeScreen: undefined;
-    AddWalletSelectionScreen: undefined;
+    AddWalletSelectionScreen: AddWalletSelectionScreenProps;
     AddWalletScreen: AddWalletScreenProps;
     TransactionDetailsScreen: TransactionDetailsProps;
     WalletOverviewScreen: WalletOverviewScreenProps;
@@ -188,7 +193,7 @@ type EditContactScreenProps = {
 
 export type SettingsStackParamList = {
     SettingsScreen: undefined;
-    AddWalletSelectionScreen: undefined;
+    AddWalletSelectionScreen: AddWalletSelectionScreenProps;
     AddWalletScreen: AddWalletScreenProps;
     ViewWalletsScreen: ViewWalletsScreenProps;
     WalletSettingsScreen: WalletSettingsScreenProps;


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-346

## Fix

- The `Back to` button text now displays either `home` or `wallets` depending on which screen the `Add a Wallet` process started from
- Updated system tests
- Updated UI to match UI mockups

![337033802_1249896212591927_7265534309506273067_n](https://user-images.githubusercontent.com/15861967/228354327-61365d54-a866-4890-a786-c7024f96ef66.jpg)
![334775379_1195516637811190_3312314128262059804_n](https://user-images.githubusercontent.com/15861967/228354329-36a76deb-d69f-4ad0-ade0-d140c23ff6c7.jpg)
![337276492_748075190100678_7169874462856035550_n](https://user-images.githubusercontent.com/15861967/228354331-e5ef4337-8d28-4b70-a2eb-a098e5ad6c5c.jpg)
![334549123_3610048149314946_2741199791311150104_n](https://user-images.githubusercontent.com/15861967/228354333-f143c4a0-fafd-49fa-8a4a-1e5f2eaa4bff.jpg)
