### PR TITLE
CRYP-347: Fix reset button in filter contact screen displaying when no contact selected

### DIFF
--- a/packages/client/screens/filters/FilterContactScreen.tsx
+++ b/packages/client/screens/filters/FilterContactScreen.tsx
@@ -17,12 +17,17 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
 
     const { token, user } = React.useContext(AuthContext);
     const [contactsWithHeader, setContactsWithHeader] = React.useState<ContactWithHeader[]>([]);
+    const [contactFilters, setContactFilters] = React.useState<string[]>([...route.params.contactFilters]);
 
     async function handleCheckboxChange(contact: string) {
-        if (route.params.contactFilters.includes(contact)) {
+        if (contactFilters.includes(contact)) {
+            setContactFilters((prev) => prev.filter((c) => c !== contact));
+
             route.params.contactFilters.splice(route.params.contactFilters.indexOf(contact), 1);
             route.params.setContactFilters(route.params.contactFilters);
         } else {
+            setContactFilters((prev) => [...prev, contact]);
+
             route.params.contactFilters.push(contact);
             route.params.setContactFilters([...route.params.contactFilters]);
         }
@@ -60,17 +65,20 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
     React.useEffect(() => {
         (() => {
             navigation.setOptions({
-                headerRight: () => (
-                    <Pressable
-                        onPress={() => {
-                            route.params.contactFilters.splice(0);
-                            route.params.setContactFilters([]);
-                            navigation.goBack();
-                        }}
-                    >
-                        <Text color={"#007AFF"}>Reset</Text>
-                    </Pressable>
-                ),
+                headerRight: () =>
+                    contactFilters.length > 0 && (
+                        <Pressable
+                            onPress={() => {
+                                route.params.contactFilters.splice(0);
+                                route.params.setContactFilters([]);
+                                setContactFilters([...route.params.contactFilters]);
+                            }}
+                        >
+                            <Text color={"#007AFF"} fontWeight={"semibold"}>
+                                Reset
+                            </Text>
+                        </Pressable>
+                    ),
             });
         })();
     });
@@ -83,51 +91,44 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
         <View style={styles.view}>
             {contactsWithHeader.length === 0 ? (
                 <Center alignItems="center" marginY="auto">
-                    <Box marginTop="-10px"></Box>
-                    <FontAwesomeIcon icon={falAddressBook} style={styles.contactBook} size={56} />
-                    <Text style={styles.contactBookText}>You do not have any contacts.</Text>
+                    <FontAwesomeIcon icon={falAddressBook} size={56} />
+                    <Text marginTop={"15px"}>You do not have any contacts.</Text>
                 </Center>
             ) : (
-                <FlatList
-                    data={contactsWithHeader}
-                    renderItem={({ item }) => (
-                        <>
-                            {item.header ? (
-                                <Box background={"text.100"}>
-                                    <Text
-                                        color={"text.500"}
-                                        fontWeight={"semibold"}
-                                        style={{ paddingHorizontal: 15, paddingVertical: 5 }}
-                                    >
-                                        {item.contact.contactName}
-                                    </Text>
-                                </Box>
-                            ) : (
-                                <HStack>
-                                    {route.params.contactFilters.includes(item.contact.contactName) ? (
+                <>
+                    <FlatList
+                        data={contactsWithHeader}
+                        renderItem={({ item }) => (
+                            <>
+                                {item.header ? (
+                                    <Box background={"text.100"}>
+                                        <Text
+                                            color={"text.500"}
+                                            fontWeight={"semibold"}
+                                            style={{ paddingHorizontal: 15, paddingVertical: 5 }}
+                                        >
+                                            {item.contact.contactName}
+                                        </Text>
+                                    </Box>
+                                ) : (
+                                    <HStack key={item.contact.contactName}>
                                         <Checkbox
-                                            style={{ paddingVertical: 10, marginHorizontal: 15 }}
+                                            style={{ paddingVertical: 10, marginLeft: 15 }}
                                             value={item.contact.contactName}
-                                            defaultIsChecked
+                                            isChecked={contactFilters.includes(item.contact.contactName)}
                                             onChange={() => handleCheckboxChange(item.contact.contactName)}
                                         >
-                                            <Text style={{ paddingVertical: 10 }}>{item.contact.contactName}</Text>
+                                            <Text style={{ paddingVertical: 10, paddingRight: 15 }} isTruncated>
+                                                {item.contact.contactName}
+                                            </Text>
                                         </Checkbox>
-                                    ) : (
-                                        <Checkbox
-                                            style={{ paddingVertical: 10, marginHorizontal: 15 }}
-                                            value={item.contact.contactName}
-                                            onChange={() => handleCheckboxChange(item.contact.contactName)}
-                                        >
-                                            <Text style={{ paddingVertical: 10 }}>{item.contact.contactName}</Text>
-                                        </Checkbox>
-                                    )}
-                                </HStack>
-                            )}
-                        </>
-                    )}
-                    stickyHeaderIndices={stickyHeaderIndices}
-                />
+                                    </HStack>
+                                )}
+                            </>
+                        )}
+                        stickyHeaderIndices={stickyHeaderIndices}
+                    />
+                </>
             )}
         </View>
     );
@@ -143,23 +144,5 @@ const styles = StyleSheet.create({
         flex: 1,
         paddingBottom: 15,
         paddingTop: 20,
-    },
-    RadioItem: {
-        marginTop: 20,
-    },
-    applyButton: {
-        marginTop: "auto",
-    },
-    applyButtonDisabled: {
-        marginTop: "auto",
-        opacity: 0.6,
-    },
-    contactBook: {
-        alignItems: "center",
-    },
-    contactBookText: {
-        textAlign: "center",
-        maxWidth: 265,
-        marginTop: 15,
     },
 });

--- a/packages/client/theme/components/checkbox.ts
+++ b/packages/client/theme/components/checkbox.ts
@@ -1,0 +1,35 @@
+export const checkbox = {
+    baseStyle: {
+        borderWidth: 1,
+        p: 1,
+        bg: "white",
+        borderColor: "text.300",
+        _checked: {
+            borderColor: `darkBlue.500`,
+            bg: `darkBlue.500`,
+            _icon: {
+                color: `muted.50`,
+            },
+            _hover: {
+                borderColor: `darkBlue.500`,
+                _icon: { color: `darkBlue.500` },
+            },
+            _pressed: {
+                borderColor: `darkBlue.500`,
+                bg: `darkBlue.500`,
+                _icon: { color: `muted.50` },
+            },
+        },
+        _stack: {
+            space: 15,
+        },
+    },
+    defaultProps: {
+        size: "md",
+        _text: {
+            color: "text.700",
+            fontSize: "body",
+            lineHeight: "body",
+        },
+    },
+};

--- a/packages/client/theme/extendTheme.tsx
+++ b/packages/client/theme/extendTheme.tsx
@@ -6,6 +6,7 @@ import { input } from "./components/input";
 import { formControlErrorMessage } from "./components/form-control";
 import { ActionsheetContent, ActionsheetItem } from "./components/actionsheet";
 import { radio } from "./components/radio";
+import { checkbox } from "./components/checkbox";
 
 export default function () {
     return extendTheme({
@@ -18,6 +19,7 @@ export default function () {
             ActionsheetContent: ActionsheetContent,
             ActionsheetItem: ActionsheetItem,
             Radio: radio,
+            Checkbox: checkbox,
         },
     });
 }


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-347

## Fix

- The `Reset` button is no longer displayed in the `Filter by Contact` screen when there isn't a contact selected
- Add custom theme for checkbox component
- Update UI to match UI mockups

![336692950_241359904922305_3951740410547637653_n](https://user-images.githubusercontent.com/15861967/228400117-ea47b45b-8c85-41f2-8e64-299ef9a35c14.jpg)
![336932778_3422604981287045_3114397546478301233_n](https://user-images.githubusercontent.com/15861967/228400118-376c3e31-cc42-4f7a-bebd-b42d0dc4b82f.jpg)
![334541893_2403310343195368_9066510174712303673_n](https://user-images.githubusercontent.com/15861967/228400201-f0f92efe-ebcf-4f70-8148-aa05b87a740d.jpg)
