### PR TITLE
CRYP-348: Fix add another Bitcoin/Ethereum wallet button always displaying in add contact form

### DIFF
--- a/packages/client/components/contacts/CollapsibleFormSection.tsx
+++ b/packages/client/components/contacts/CollapsibleFormSection.tsx
@@ -97,7 +97,7 @@ export default function CollapsibleFormSection({
                     render={(arrayHelpers) => (
                         <View>
                             {wallets?.map((wallet, i) => (
-                                <View key={wallet}>
+                                <View key={`${walletListString}[${i}]`}>
                                     <FormControl
                                         style={i > 1 ? { marginTop: 13 } : { marginTop: 15 }}
                                         isInvalid={!!(currencyErrors?.[i] && currencyTouched)}

--- a/packages/client/components/contacts/CollapsibleFormSection.tsx
+++ b/packages/client/components/contacts/CollapsibleFormSection.tsx
@@ -5,7 +5,6 @@ import React from "react";
 import { StyleSheet } from "react-native";
 import { FormControl, HStack, Input, Text, Pressable } from "native-base";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
-import { titleCase } from "@cryptify/common/src/utils/string_utils";
 import { farChevronDown } from "../icons/regular/farChevronDown";
 import { farChevronUp } from "../icons/regular/farChevronUp";
 import Collapsible from "react-native-collapsible";
@@ -15,6 +14,7 @@ import { falCircleXMark } from "../icons/light/falCircleXMark";
 import { farCirclePlus } from "../icons/regular/farCirclePlus";
 import { QRCodeScannerInputIcon } from "../QRCodeScannerInputIcon";
 import { CompositeNavigationProp } from "@react-navigation/native";
+import { getCurrencyTypeUILabel } from "@cryptify/common/src/utils/currency_utils";
 
 type CreateContactRequestPayload = {
     contactName: string;
@@ -56,6 +56,18 @@ export default function CollapsibleFormSection({
     const currencyTouched = currencyType === CurrencyType.BITCOIN ? touched.btcWallets : touched.ethWallets;
     const walletListString = currencyType === CurrencyType.BITCOIN ? "btcWallets" : "ethWallets";
 
+    const addWalletButtonText = (walletsAmount: number) => {
+        if (walletsAmount > 0) {
+            return "Add another " + getCurrencyTypeUILabel(currencyType) + " wallet";
+        } else {
+            if (currencyType === CurrencyType.BITCOIN) {
+                return "Add a Bitcoin wallet";
+            } else {
+                return "Add an Ethereum wallet";
+            }
+        }
+    };
+
     const [isCollapsed, setIsCollapsed] = React.useState<boolean>(initialIsCollapsed);
 
     return (
@@ -66,10 +78,10 @@ export default function CollapsibleFormSection({
                 }}
                 testID={`walletCollapsibleButton${currencyType}`}
             >
-                <HStack style={{ marginTop: 40 }}>
-                    <FontAwesomeIcon style={{ marginRight: 10 }} color={iconColor} icon={currencyIcon} size={26} />
-                    <Text fontWeight={"semibold"} size={"title3"}>
-                        {titleCase(currencyType)} Wallets
+                <HStack marginTop={"35px"} alignItems="center">
+                    <FontAwesomeIcon color={iconColor} icon={currencyIcon} size={26} />
+                    <Text fontWeight={"semibold"} size={"title3"} marginLeft={"10px"}>
+                        {getCurrencyTypeUILabel(currencyType)} Wallets
                     </Text>
                     {isCollapsed ? (
                         <FontAwesomeIcon style={styles.chevronIcon} size={18} icon={farChevronDown} />
@@ -85,8 +97,11 @@ export default function CollapsibleFormSection({
                     render={(arrayHelpers) => (
                         <View>
                             {wallets?.map((wallet, i) => (
-                                <View style={wallets.length > 1 ? { marginTop: 13 } : { marginTop: 20 }} key={wallet}>
-                                    <FormControl isInvalid={!!(currencyErrors?.[i] && currencyTouched)}>
+                                <View key={wallet}>
+                                    <FormControl
+                                        style={i > 1 ? { marginTop: 13 } : { marginTop: 15 }}
+                                        isInvalid={!!(currencyErrors?.[i] && currencyTouched)}
+                                    >
                                         <Input
                                             value={wallet}
                                             onChangeText={handleChange(`${walletListString}[${i}]`)}
@@ -134,14 +149,10 @@ export default function CollapsibleFormSection({
                                         }}
                                         testID={`addAnother${currencyType}`}
                                     >
-                                        <HStack style={{ marginTop: 13 }} alignItems={"center"}>
+                                        <HStack style={{ marginTop: 15 }} space={"10px"} alignItems={"center"}>
                                             <FontAwesomeIcon color={"#0077E6"} icon={farCirclePlus} size={18} />
-                                            <Text
-                                                style={{ marginLeft: 10 }}
-                                                color={"darkBlue.500"}
-                                                fontWeight={"semibold"}
-                                            >
-                                                Add another {titleCase(currencyType)} wallet
+                                            <Text color={"darkBlue.500"} fontWeight={"semibold"} size={"callout"}>
+                                                {addWalletButtonText(wallets.length)}
                                             </Text>
                                         </HStack>
                                     </Pressable>
@@ -159,5 +170,6 @@ const styles = StyleSheet.create({
     chevronIcon: {
         marginLeft: "auto",
         marginRight: 5,
+        color: "#A3A3A3",
     },
 });

--- a/packages/client/screens/contacts/AddContactScreen.tsx
+++ b/packages/client/screens/contacts/AddContactScreen.tsx
@@ -27,8 +27,5 @@ export default function AddContactScreen(props: Props) {
 const styles = StyleSheet.create({
     view: {
         flex: 1,
-        paddingHorizontal: 15,
-        paddingTop: 30,
-        paddingBottom: 15,
     },
 });

--- a/packages/client/screens/contacts/ContactsListScreen.tsx
+++ b/packages/client/screens/contacts/ContactsListScreen.tsx
@@ -133,6 +133,7 @@ type ContactWithHeader = {
 const styles = StyleSheet.create({
     view: {
         flex: 1,
+        paddingTop: 20,
     },
     contactBook: {
         alignItems: "center",

--- a/packages/client/screens/contacts/EditContactScreen.tsx
+++ b/packages/client/screens/contacts/EditContactScreen.tsx
@@ -105,8 +105,8 @@ export default function EditContactScreen(props: SettingsStackScreenProps<"EditC
 
     return (
         <View style={styles.view}>
-            <ScrollView style={styles.scrollView}>
-                <VStack space={"35px"} paddingTop={"30px"} paddingBottom={"10px"}>
+            <ScrollView>
+                <VStack>
                     <ContactsForm
                         prefilledWalletAddress={undefined}
                         contact={props.route.params.contact}
@@ -119,6 +119,7 @@ export default function EditContactScreen(props: SettingsStackScreenProps<"EditC
                         _text={{ color: "error.500" }}
                         onPress={handleDeleteContact}
                         testID="deleteContactButton"
+                        style={styles.deleteButton}
                     >
                         Delete contact
                     </Button>
@@ -132,7 +133,9 @@ const styles = StyleSheet.create({
     view: {
         flex: 1,
     },
-    scrollView: {
-        paddingHorizontal: 15,
+    deleteButton: {
+        marginHorizontal: 15,
+        marginTop: -85,
+        marginBottom: 15,
     },
 });

--- a/packages/common/src/errors/error_messages.ts
+++ b/packages/common/src/errors/error_messages.ts
@@ -15,6 +15,9 @@ export const ERROR_TAG_NAME_ALREADY_EXIST = "This tag already exists.";
 export const ERROR_TAG_NOT_FOUND = "Transaction tag not found.";
 export const ERROR_TRANSACTIONS_NOT_FOUND = "One or more transactions not found.";
 
+export const ERROR_CONTACT_NAME_EMPTY = "Enter a name.";
+export const ERROR_CONTACT_NAME_TOO_LONG = "Name must be 65 characters or less.";
+export const ERROR_CONTACT_NAME_INVALID_CHARACTERS = "Name must only contain alphabetic characters and spaces.";
 export const ERROR_CONTACT_NAME_ALREADY_ADDED_TO_ACCOUNT = "This name is already associated with another contact.";
 export const ERROR_ADDRESS_ALREADY_ADDED_TO_CONTACT =
     "This Bitcoin wallet address is already associated with another contact.";


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-348

## Fix

- The `Add another Bitcoin/Ethereum wallet` button will only display when there is at least 1 form field for their respective form sections in both the add and edit contact forms
- Updated all UIs to match UI mockups
- Fixed contact name error messages not displaying on the form according to the specs

![334870718_1148522162483750_8835498603333968719_n](https://user-images.githubusercontent.com/15861967/228610040-749ba996-6a5a-4846-bb2d-32c86b3b976d.jpg)
![337384500_595427029156161_7352598970098712513_n](https://user-images.githubusercontent.com/15861967/228610042-426df41d-613d-46cd-81d7-2524cd03d2cc.jpg)
![334717746_156117257375696_94623433409372583_n](https://user-images.githubusercontent.com/15861967/228610043-f35ac996-960d-4be7-9cc0-1d492aafa690.jpg)
![337056187_250225020759731_8312907940703409469_n](https://user-images.githubusercontent.com/15861967/228610044-a074c761-c6e9-4334-9b85-9c9dd25b1bcf.jpg)
![337337012_8975058099232797_6127464979472200548_n](https://user-images.githubusercontent.com/15861967/228610045-99a22277-f637-4fdf-88ab-8c323ca339e0.jpg)
![337362664_949912209789842_3508562308948122999_n](https://user-images.githubusercontent.com/15861967/228610047-295e32a7-f996-4aa7-9521-059b5b9f5348.jpg)

