### PR TITLE
CRYP-350: Fix edit button displaying in tags list when no tags are added

### DIFF
--- a/packages/client/screens/TagsSettingsScreen.tsx
+++ b/packages/client/screens/TagsSettingsScreen.tsx
@@ -38,11 +38,7 @@ export default function TagsSettingsScreen(props: SettingsStackScreenProps<"Tags
             props.navigation.setOptions({
                 headerRight: () => (
                     <>
-                        <Pressable
-                            onPress={() => props.navigation.navigate("AddTagsScreen")}
-                            style={styles.plusIcon}
-                            testID="addTagButton"
-                        >
+                        <Pressable onPress={() => props.navigation.navigate("AddTagsScreen")} testID="addTagButton">
                             <FontAwesomeIcon icon={farPlus} color="#404040" size={22} />
                         </Pressable>
                         {isEditMode ? (
@@ -54,19 +50,25 @@ export default function TagsSettingsScreen(props: SettingsStackScreenProps<"Tags
                                     fontWeight: "semibold",
                                 }}
                                 testID="editTagDone"
+                                marginLeft={"15px"}
                             >
                                 Done
                             </Link>
-                        ) : (
-                            <Link onPress={() => setIsEditMode(true)} isUnderlined={false} testID="editTagEdit">
+                        ) : tags.length > 0 ? (
+                            <Link
+                                onPress={() => setIsEditMode(true)}
+                                isUnderlined={false}
+                                testID="editTagEdit"
+                                marginLeft={"15px"}
+                            >
                                 Edit
                             </Link>
-                        )}
+                        ) : null}
                     </>
                 ),
             });
         })();
-    }, [isEditMode]);
+    }, [isEditMode, tags]);
 
     return tags.length === 0 ? (
         <View style={styles.view}>
@@ -105,8 +107,5 @@ const styles = StyleSheet.create({
     },
     tagIcon: {
         color: "#404040",
-    },
-    plusIcon: {
-        marginRight: 15,
     },
 });


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-350

## Fix

- Edit button in settings tags list is only displayed when at least 1 tag has been added to the account

![336755037_144481275246497_8947374684889503727_n](https://user-images.githubusercontent.com/15861967/228684938-cec1dd8f-c37c-4a61-ab68-d8b2ff93b45c.jpg)
![337462630_758767812439343_400998526045172388_n](https://user-images.githubusercontent.com/15861967/228684939-4c0a1a70-f94a-481a-a202-edb41110b6d0.jpg)
