### PR TITLE
CRYP-352: Fix transaction filter screens to matching UI mockups

### DIFF
--- a/packages/client/components/SaveFilterActionSheet.tsx
+++ b/packages/client/components/SaveFilterActionSheet.tsx
@@ -20,13 +20,12 @@ import { FiltersGateway } from "../gateways/filters_gateway";
 import { CurrencyType } from "@cryptify/common/src/domain/currency_type";
 import { AuthContext } from "./contexts/AuthContext";
 import { useKeyboardBottomInset } from "../hooks/useKeyboardBottomInset";
+import { getFiltersByDateStrings } from "../services/filter_service";
 
 type Props = {
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     filterByTransaction: string;
     filterByDate: string;
-    fromDate: Date | null;
-    toDate: Date | null;
     currencyType: CurrencyType;
     setIsUsingSavedFilter: React.Dispatch<React.SetStateAction<boolean>>;
     setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
@@ -38,8 +37,6 @@ export default function SaveFilterActionSheet({
     setIsFilterSaved,
     filterByTransaction,
     filterByDate,
-    fromDate,
-    toDate,
     currencyType,
 }: Props) {
     const filtersGateway = new FiltersGateway();
@@ -54,25 +51,21 @@ export default function SaveFilterActionSheet({
         name: "",
     };
 
+    const filtersByDate = getFiltersByDateStrings();
+
     async function onSubmit(values: any, formikHelpers: any) {
         try {
             const filters = [filterByTransaction];
 
-            // this checks if the filter selected for the date is "custom date"
-            // since we need to have special logic that would add the two dates selected
-            if (filterByDate === "Custom Dates" && fromDate && toDate) {
-                const dateFormate = new Intl.DateTimeFormat("en-US", {
-                    year: "numeric",
-                    month: "short",
-                    day: "2-digit",
-                });
-
-                filters.push(`${dateFormate.format(fromDate)} - ${dateFormate.format(toDate)}`);
+            // If a custom date is selected, but at least one of the from or to dates are not selected,
+            // then filterByDate value will be "Custom Dates" and not the date range. In this scenario,
+            // use the default date filter value.
+            if (filterByDate === "Custom Dates") {
+                filters.push(filtersByDate[0]);
             } else {
-                if (filterByDate !== "Custom Dates") {
-                    filters.push(filterByDate);
-                }
+                filters.push(filterByDate);
             }
+
             setFilters(filters);
 
             const req = {

--- a/packages/client/components/SaveFilterActionSheet.tsx
+++ b/packages/client/components/SaveFilterActionSheet.tsx
@@ -26,6 +26,8 @@ type Props = {
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     filterByTransaction: string;
     filterByDate: string;
+    filterByContact: string[];
+    filterByTag: string[];
     currencyType: CurrencyType;
     setIsUsingSavedFilter: React.Dispatch<React.SetStateAction<boolean>>;
     setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;

--- a/packages/client/components/SaveFilterActionSheet.tsx
+++ b/packages/client/components/SaveFilterActionSheet.tsx
@@ -29,16 +29,16 @@ type Props = {
     filterByContact: string[];
     filterByTag: string[];
     currencyType: CurrencyType;
-    setIsUsingSavedFilter: React.Dispatch<React.SetStateAction<boolean>>;
     setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export default function SaveFilterActionSheet({
     setFilters,
-    setIsUsingSavedFilter,
     setIsFilterSaved,
     filterByTransaction,
     filterByDate,
+    filterByContact,
+    filterByTag,
     currencyType,
 }: Props) {
     const filtersGateway = new FiltersGateway();
@@ -77,8 +77,8 @@ export default function SaveFilterActionSheet({
                 txnIn: true,
                 txnOut: true,
                 range: filters[1],
-                tagNames: [],
-                contactNames: [],
+                tagNames: [...filterByTag],
+                contactNames: [...filterByContact],
             };
             if (filterByTransaction.endsWith("in")) {
                 req.txnIn = true;
@@ -91,7 +91,6 @@ export default function SaveFilterActionSheet({
             await filtersGateway.createFilter(req, token);
 
             onClose();
-            setIsUsingSavedFilter(true);
             setIsFilterSaved(true);
             toast.show({
                 placement: "top",

--- a/packages/client/components/icons/light/falBookmark.tsx
+++ b/packages/client/components/icons/light/falBookmark.tsx
@@ -1,0 +1,18 @@
+import { IconDefinition, IconName, IconPrefix } from "@fortawesome/fontawesome-svg-core";
+
+export const falBookmark: IconDefinition = {
+    icon: [
+        // SVG viewbox width (in pixels)
+        384,
+        // SVG viewbox height (in pixels)
+        512,
+        // Aliases (not needed)
+        [],
+        // Unicode as hex value (not needed)
+        "f02e",
+        // SVG path data
+        "M320 0H64C28.72 0 0 28.7 0 64v431.1c0 5.844 3.188 11.23 8.312 14.04c5.125 2.781 11.34 2.562 16.28-.5313L192 402.1l167.4 106.5C362 511.2 365 512 368 512c2.656 0 5.281-.6562 7.688-1.969C380.8 507.2 384 501.8 384 495.1V64C384 28.7 355.3 0 320 0zM352 466.9l-151.4-96.36C197.1 368.8 195 368 192 368s-5.969 .8281-8.594 2.5L32 466.9V64c0-17.64 14.34-32 32-32h256c17.66 0 32 14.36 32 32V466.9z",
+    ],
+    iconName: "fac-bookmark" as IconName,
+    prefix: "fac-light" as IconPrefix,
+};

--- a/packages/client/navigation/index.tsx
+++ b/packages/client/navigation/index.tsx
@@ -61,6 +61,7 @@ import AccountPasswordScreen from "../screens/account/AccountPasswordScreen";
 import SavedFiltersScreen from "../screens/filters/SavedFiltersScreen";
 import FilterContactScreen from "../screens/filters/FilterContactScreen";
 import FilterTagScreen from "../screens/filters/FilterTagScreen";
+import FilterDateScreen from "../screens/filters/FilterDateScreen";
 import QRCodeScannerScreen from "../screens/QRCodeScannerScreen";
 import ResetPasswordEmailScreen from "../screens/reset-password/resetPasswordEmailScreen";
 import CreateNewPasswordScreen from "../screens/reset-password/createNewPasswordScreen";
@@ -253,6 +254,20 @@ function HomeStackScreen({ navigation, route }: { route: RouteProp<any, any>; na
                 component={SavedFiltersScreen}
                 options={{
                     title: "Saved Filters",
+                    headerTintColor: "#404040",
+                    headerTitleStyle: {
+                        fontSize: 17,
+                        fontWeight: "600",
+                    },
+                    headerShadowVisible: false,
+                    headerTitleAlign: "center",
+                }}
+            />
+            <HomeStack.Screen
+                name="FilterDateScreen"
+                component={FilterDateScreen}
+                options={{
+                    title: "Filter by Date",
                     headerTintColor: "#404040",
                     headerTitleStyle: {
                         fontSize: 17,

--- a/packages/client/screens/TagsSettingsScreen.tsx
+++ b/packages/client/screens/TagsSettingsScreen.tsx
@@ -38,11 +38,7 @@ export default function TagsSettingsScreen(props: SettingsStackScreenProps<"Tags
             props.navigation.setOptions({
                 headerRight: () => (
                     <>
-                        <Pressable
-                            onPress={() => props.navigation.navigate("AddTagsScreen")}
-                            style={styles.plusIcon}
-                            testID="addTagButton"
-                        >
+                        <Pressable onPress={() => props.navigation.navigate("AddTagsScreen")} testID="addTagButton">
                             <FontAwesomeIcon icon={farPlus} color="#404040" size={22} />
                         </Pressable>
                         {isEditMode ? (
@@ -54,19 +50,25 @@ export default function TagsSettingsScreen(props: SettingsStackScreenProps<"Tags
                                     fontWeight: "semibold",
                                 }}
                                 testID="editTagDone"
+                                marginLeft={"15px"}
                             >
                                 Done
                             </Link>
-                        ) : (
-                            <Link onPress={() => setIsEditMode(true)} isUnderlined={false} testID="editTagEdit">
+                        ) : tags.length > 0 ? (
+                            <Link
+                                onPress={() => setIsEditMode(true)}
+                                isUnderlined={false}
+                                testID="editTagEdit"
+                                marginLeft={"15px"}
+                            >
                                 Edit
                             </Link>
-                        )}
+                        ) : null}
                     </>
                 ),
             });
         })();
-    }, [isEditMode]);
+    }, [isEditMode, tags]);
 
     return tags.length === 0 ? (
         <View style={styles.view}>
@@ -105,8 +107,5 @@ const styles = StyleSheet.create({
     },
     tagIcon: {
         color: "#404040",
-    },
-    plusIcon: {
-        marginRight: 15,
     },
 });

--- a/packages/client/screens/TransactionsListScreen.tsx
+++ b/packages/client/screens/TransactionsListScreen.tsx
@@ -10,13 +10,20 @@ import { Pressable, Text, HStack, ScrollView, VStack, Center, Link } from "nativ
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { farBarsFilter } from "../components/icons/regular/farBarsFilter";
 import { facCircleXMark } from "../components/icons/solid/fasCircleXMark";
-import { filterTransactions } from "../services/filter_service";
+import {
+    filterTransactions,
+    getFiltersByDateStrings,
+    getFiltersByTransactionStrings,
+} from "../services/filter_service";
 import { falMagnifyingGlass } from "../components/icons/light/falMagnifyingGlass";
 
 export default function TransactionsListScreen(props: HomeStackScreenProps<"TransactionsListScreen">) {
+    const filtersByTransaction = getFiltersByTransactionStrings(props.route.params.wallet.currencyType);
+    const filtersByDate = getFiltersByDateStrings();
+
     const [transactions, setTransactions] = React.useState<Transaction[]>([...props.route.params.transactions]);
     const [sortType, setSortType] = React.useState("sortDateNewest");
-    const [filters, setFilters] = React.useState<string[]>([]);
+    const [filters, setFilters] = React.useState<string[]>([filtersByTransaction[0], filtersByDate[0]]);
     const [isUsingSavedFilter, setIsUsingSavedFilter] = React.useState(false);
     const [contactFilters, setContactFilters] = React.useState<string[]>([]);
     const [tagFilters, setTagFilters] = React.useState<string[]>([]);

--- a/packages/client/screens/TransactionsListScreen.tsx
+++ b/packages/client/screens/TransactionsListScreen.tsx
@@ -116,8 +116,11 @@ export default function TransactionsListScreen(props: HomeStackScreenProps<"Tran
 
                         <Pressable
                             onPress={() => {
-                                // This removes the current filter when the XMark is pressed.
-                                setFilters(filtersDisplayed.filter((f) => f !== filter));
+                                // Get the index of the filter that was pressed in the filters array and replace it with "All transactions"
+                                const index = filters.indexOf(filter);
+                                const newFilters = [...filters];
+                                newFilters[index] = "All transactions";
+                                setFilters(newFilters);
                             }}
                         >
                             <FontAwesomeIcon style={{ color: "#0077E6" }} icon={facCircleXMark} size={14} />

--- a/packages/client/screens/TransactionsListScreen.tsx
+++ b/packages/client/screens/TransactionsListScreen.tsx
@@ -103,6 +103,27 @@ export default function TransactionsListScreen(props: HomeStackScreenProps<"Tran
                     </Pressable>
                 </HStack>
 
+                {filtersDisplayed.map((filter) => (
+                    <HStack key={filter} style={styles.badge}>
+                        <Text
+                            size={"footnote1"}
+                            fontWeight={"semibold"}
+                            color={"darkBlue.500"}
+                            style={styles.badgeText}
+                        >
+                            {filter}
+                        </Text>
+
+                        <Pressable
+                            onPress={() => {
+                                // This removes the current filter when the XMark is pressed.
+                                setFilters(filtersDisplayed.filter((f) => f !== filter));
+                            }}
+                        >
+                            <FontAwesomeIcon style={{ color: "#0077E6" }} icon={facCircleXMark} size={14} />
+                        </Pressable>
+                    </HStack>
+                ))}
                 {/*Since contacts use a different filter array, we need to have render the badge separately*/}
                 {contactFilters.map((filter) => (
                     <HStack key={filter} style={styles.badge}>
@@ -140,28 +161,6 @@ export default function TransactionsListScreen(props: HomeStackScreenProps<"Tran
                             onPress={() => {
                                 // This removes the current filter when the XMark is pressed.
                                 setTagFilters(tagFilters.filter((f) => f !== filter));
-                            }}
-                        >
-                            <FontAwesomeIcon style={{ color: "#0077E6" }} icon={facCircleXMark} size={14} />
-                        </Pressable>
-                    </HStack>
-                ))}
-
-                {filtersDisplayed.map((filter) => (
-                    <HStack key={filter} style={styles.badge}>
-                        <Text
-                            size={"footnote1"}
-                            fontWeight={"semibold"}
-                            color={"darkBlue.500"}
-                            style={styles.badgeText}
-                        >
-                            {filter}
-                        </Text>
-
-                        <Pressable
-                            onPress={() => {
-                                // This removes the current filter when the XMark is pressed.
-                                setFilters(filtersDisplayed.filter((f) => f !== filter));
                             }}
                         >
                             <FontAwesomeIcon style={{ color: "#0077E6" }} icon={facCircleXMark} size={14} />

--- a/packages/client/screens/TransactionsListScreen.tsx
+++ b/packages/client/screens/TransactionsListScreen.tsx
@@ -133,7 +133,7 @@ export default function TransactionsListScreen(props: HomeStackScreenProps<"Tran
                             color={"darkBlue.500"}
                             style={styles.badgeText}
                         >
-                            {filter}
+                            {"Tag: " + filter}
                         </Text>
 
                         <Pressable

--- a/packages/client/screens/filters/FilterContactScreen.tsx
+++ b/packages/client/screens/filters/FilterContactScreen.tsx
@@ -25,11 +25,13 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
 
             route.params.filterByContact.splice(route.params.filterByContact.indexOf(contact), 1);
             route.params.setFilterByContact(route.params.filterByContact);
+            route.params.setIsFilterSaved(false);
         } else {
             setContactFilters((prev) => [...prev, contact]);
 
             route.params.filterByContact.push(contact);
             route.params.setFilterByContact([...route.params.filterByContact]);
+            route.params.setIsFilterSaved(false);
         }
     }
 
@@ -72,6 +74,7 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
                                 route.params.filterByContact.splice(0);
                                 route.params.setFilterByContact([]);
                                 setContactFilters([...route.params.filterByContact]);
+                                route.params.setIsFilterSaved(false);
                             }}
                         >
                             <Text color={"#007AFF"} fontWeight={"semibold"}>

--- a/packages/client/screens/filters/FilterContactScreen.tsx
+++ b/packages/client/screens/filters/FilterContactScreen.tsx
@@ -17,19 +17,19 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
 
     const { token, user } = React.useContext(AuthContext);
     const [contactsWithHeader, setContactsWithHeader] = React.useState<ContactWithHeader[]>([]);
-    const [contactFilters, setContactFilters] = React.useState<string[]>([...route.params.contactFilters]);
+    const [contactFilters, setContactFilters] = React.useState<string[]>([...route.params.filterByContact]);
 
     async function handleCheckboxChange(contact: string) {
         if (contactFilters.includes(contact)) {
             setContactFilters((prev) => prev.filter((c) => c !== contact));
 
-            route.params.contactFilters.splice(route.params.contactFilters.indexOf(contact), 1);
-            route.params.setContactFilters(route.params.contactFilters);
+            route.params.filterByContact.splice(route.params.filterByContact.indexOf(contact), 1);
+            route.params.setFilterByContact(route.params.filterByContact);
         } else {
             setContactFilters((prev) => [...prev, contact]);
 
-            route.params.contactFilters.push(contact);
-            route.params.setContactFilters([...route.params.contactFilters]);
+            route.params.filterByContact.push(contact);
+            route.params.setFilterByContact([...route.params.filterByContact]);
         }
     }
 
@@ -69,9 +69,9 @@ export default function FilterContactScreen({ route, navigation }: HomeStackScre
                     contactFilters.length > 0 && (
                         <Pressable
                             onPress={() => {
-                                route.params.contactFilters.splice(0);
-                                route.params.setContactFilters([]);
-                                setContactFilters([...route.params.contactFilters]);
+                                route.params.filterByContact.splice(0);
+                                route.params.setFilterByContact([]);
+                                setContactFilters([...route.params.filterByContact]);
                             }}
                         >
                             <Text color={"#007AFF"} fontWeight={"semibold"}>

--- a/packages/client/screens/filters/FilterDateScreen.tsx
+++ b/packages/client/screens/filters/FilterDateScreen.tsx
@@ -15,6 +15,8 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     const [fromDate, setFromDate] = React.useState<Date | null>(getFromDate());
     const [toDate, setToDate] = React.useState<Date | null>(getToDate());
 
+    console.log("FilterDateScreen: " + JSON.stringify(route.params.filterByDate));
+
     function getFilterByDate() {
         if (route.params.filterByDate) {
             if (filtersByDate.includes(route.params.filterByDate)) {
@@ -28,7 +30,7 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     }
 
     function getFromDate(): Date | null {
-        if (route.params.filters[1]) {
+        if (route.params.filterByDate) {
             // Filter is a custom date
             if (!filtersByDate.includes(route.params.filterByDate)) {
                 return new Date(route.params.filterByDate.split(" - ")[0]);
@@ -39,7 +41,7 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     }
 
     function getToDate(): Date | null {
-        if (route.params.filters[1]) {
+        if (route.params.filterByDate) {
             // Filter is a custom date
             if (!filtersByDate.includes(route.params.filterByDate)) {
                 return new Date(route.params.filterByDate.split(" - ")[1]);
@@ -81,8 +83,6 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     React.useEffect(() => {
         if (fromDate && toDate) {
             const customDate = `${getFormattedDate(fromDate.toString())} - ${getFormattedDate(toDate.toString())}`;
-            route.params.filters[1] = customDate;
-            route.params.setFilters(route.params.filters);
             route.params.setFilterByDate(customDate);
         }
     }, [toDate, fromDate]);
@@ -90,8 +90,6 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     function handleRadioChange(nextValue: string) {
         setFilterByDate(nextValue);
         route.params.setFilterByDate(nextValue);
-        route.params.filters[1] = nextValue;
-        route.params.setFilters(route.params.filters);
     }
 
     type RadioProps = {

--- a/packages/client/screens/filters/FilterDateScreen.tsx
+++ b/packages/client/screens/filters/FilterDateScreen.tsx
@@ -15,8 +15,6 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     const [fromDate, setFromDate] = React.useState<Date | null>(getFromDate());
     const [toDate, setToDate] = React.useState<Date | null>(getToDate());
 
-    console.log("FilterDateScreen: " + JSON.stringify(route.params.filterByDate));
-
     function getFilterByDate() {
         if (route.params.filterByDate) {
             if (filtersByDate.includes(route.params.filterByDate)) {

--- a/packages/client/screens/filters/FilterDateScreen.tsx
+++ b/packages/client/screens/filters/FilterDateScreen.tsx
@@ -1,0 +1,158 @@
+import { View } from "../../components/Themed";
+import { Pressable, StyleSheet } from "react-native";
+import { Text, HStack, Box, Radio } from "native-base";
+import { HomeStackScreenProps } from "../../types";
+import React from "react";
+import DateBox from "../../components/DateBox";
+import { getFiltersByDateStrings } from "../../services/filter_service";
+
+export default function FilterDateScreen({ route, navigation }: HomeStackScreenProps<"FilterDateScreen">) {
+    const filtersByDate = getFiltersByDateStrings();
+
+    const [filterByDate, setFilterByDate] = React.useState(getFilterByDate());
+
+    // Get the from and to dates from the following Custom Dates format: Mon DD, YYYY - Mon DD, YYYY
+    const [fromDate, setFromDate] = React.useState<Date | null>(getFromDate());
+    const [toDate, setToDate] = React.useState<Date | null>(getToDate());
+
+    function getFilterByDate() {
+        if (route.params.filterByDate) {
+            if (filtersByDate.includes(route.params.filterByDate)) {
+                return route.params.filterByDate;
+            } else {
+                return filtersByDate[filtersByDate.length - 1];
+            }
+        } else {
+            return filtersByDate[0];
+        }
+    }
+
+    function getFromDate(): Date | null {
+        if (route.params.filters[1]) {
+            // Filter is a custom date
+            if (!filtersByDate.includes(route.params.filterByDate)) {
+                return new Date(route.params.filterByDate.split(" - ")[0]);
+            }
+        }
+
+        return null;
+    }
+
+    function getToDate(): Date | null {
+        if (route.params.filters[1]) {
+            // Filter is a custom date
+            if (!filtersByDate.includes(route.params.filterByDate)) {
+                return new Date(route.params.filterByDate.split(" - ")[1]);
+            }
+        }
+
+        return null;
+    }
+
+    React.useEffect(() => {
+        (() => {
+            navigation.setOptions({
+                headerRight: () =>
+                    filterByDate !== filtersByDate[0] && (
+                        <Pressable
+                            onPress={() => {
+                                route.params.filters[1] = filtersByDate[0];
+                                setToDate(null);
+                                setFromDate(null);
+                                setFilterByDate(filtersByDate[0]);
+                                route.params.setFilterByDate(filtersByDate[0]);
+                            }}
+                        >
+                            <Text color={"#007AFF"} fontWeight={"semibold"}>
+                                Reset
+                            </Text>
+                        </Pressable>
+                    ),
+            });
+        })();
+    });
+
+    function getFormattedDate(timestamp: string): string {
+        const date = new Date(timestamp);
+        const datePart = date.toLocaleString("en-US", { month: "short", day: "numeric", year: "numeric" });
+        return `${datePart}`;
+    }
+
+    React.useEffect(() => {
+        if (fromDate && toDate) {
+            const customDate = `${getFormattedDate(fromDate.toString())} - ${getFormattedDate(toDate.toString())}`;
+            route.params.filters[1] = customDate;
+            route.params.setFilters(route.params.filters);
+            route.params.setFilterByDate(customDate);
+        }
+    }, [toDate, fromDate]);
+
+    function handleRadioChange(nextValue: string) {
+        setFilterByDate(nextValue);
+        route.params.setFilterByDate(nextValue);
+        route.params.filters[1] = nextValue;
+        route.params.setFilters(route.params.filters);
+    }
+
+    type RadioProps = {
+        value: string;
+        options: string[];
+    };
+
+    function RadioGroup({ options, value }: RadioProps) {
+        return (
+            <Radio.Group
+                name="myRadioGroup"
+                value={value}
+                onChange={(nextValue) => {
+                    handleRadioChange(nextValue);
+                }}
+            >
+                {options.map((option) => (
+                    <Box style={styles.RadioItem} key={option}>
+                        <Radio key={option} value={option} color={"darkBlue.500"}>
+                            {option}
+                        </Radio>
+                    </Box>
+                ))}
+            </Radio.Group>
+        );
+    }
+
+    function CustomDates() {
+        return (
+            <HStack>
+                <DateBox
+                    label="from"
+                    style={{ marginRight: 13 }}
+                    date={fromDate}
+                    maximumDate={toDate}
+                    setDate={setFromDate}
+                />
+                <DateBox label="to" date={toDate} minimumDate={fromDate} setDate={setToDate} />
+            </HStack>
+        );
+    }
+
+    return (
+        <View style={styles.view}>
+            <RadioGroup options={filtersByDate} value={filterByDate} />
+            {filterByDate === filtersByDate[filtersByDate.length - 1] && (
+                <>
+                    <Box marginTop="20px" />
+                    <CustomDates />
+                </>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    view: {
+        flex: 1,
+        paddingHorizontal: 15,
+    },
+    RadioItem: {
+        marginTop: 20,
+    },
+});

--- a/packages/client/screens/filters/FilterDateScreen.tsx
+++ b/packages/client/screens/filters/FilterDateScreen.tsx
@@ -15,6 +15,8 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
     const [fromDate, setFromDate] = React.useState<Date | null>(getFromDate());
     const [toDate, setToDate] = React.useState<Date | null>(getToDate());
 
+    const initialCustomDate: { fromDate: Date | null; toDate: Date | null } = { fromDate, toDate };
+
     function getFilterByDate() {
         if (route.params.filterByDate) {
             if (filtersByDate.includes(route.params.filterByDate)) {
@@ -27,7 +29,7 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
         }
     }
 
-    function getFromDate(): Date | null {
+    function getFromDate() {
         if (route.params.filterByDate) {
             // Filter is a custom date
             if (!filtersByDate.includes(route.params.filterByDate)) {
@@ -38,7 +40,7 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
         return null;
     }
 
-    function getToDate(): Date | null {
+    function getToDate() {
         if (route.params.filterByDate) {
             // Filter is a custom date
             if (!filtersByDate.includes(route.params.filterByDate)) {
@@ -61,6 +63,7 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
                                 setFromDate(null);
                                 setFilterByDate(filtersByDate[0]);
                                 route.params.setFilterByDate(filtersByDate[0]);
+                                route.params.setIsFilterSaved(false);
                             }}
                         >
                             <Text color={"#007AFF"} fontWeight={"semibold"}>
@@ -82,12 +85,17 @@ export default function FilterDateScreen({ route, navigation }: HomeStackScreenP
         if (fromDate && toDate) {
             const customDate = `${getFormattedDate(fromDate.toString())} - ${getFormattedDate(toDate.toString())}`;
             route.params.setFilterByDate(customDate);
+
+            if (initialCustomDate.fromDate !== fromDate || initialCustomDate.toDate !== toDate) {
+                route.params.setIsFilterSaved(false);
+            }
         }
     }, [toDate, fromDate]);
 
     function handleRadioChange(nextValue: string) {
         setFilterByDate(nextValue);
         route.params.setFilterByDate(nextValue);
+        route.params.setIsFilterSaved(false);
     }
 
     type RadioProps = {

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -51,7 +51,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                 onPress={() => {
                     setFilterByTransaction(filtersByTransaction[0]);
                     setFilterByDate(filtersByDate[0]);
-                    route.params.setIsUsingSavedFilter(false);
                     setFilterByContact([]);
                     setFilterByTag([]);
                     setIsFilterSaved(false);
@@ -78,10 +77,10 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             onPress={() =>
                                 navigation.navigate("SavedFiltersScreen", {
                                     currencyType: route.params.wallet.currencyType,
-                                    setFilters: route.params.setFilters,
                                     setFilterByTransaction,
                                     setFilterByDate,
-                                    setIsUsingSavedFilter: route.params.setIsUsingSavedFilter,
+                                    setFilterByContact,
+                                    setFilterByTag,
                                     setIsFilterSaved,
                                 })
                             }
@@ -153,6 +152,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilters: route.params.setFilters,
                             filterByDate,
                             setFilterByDate,
+                            setIsFilterSaved,
                         })
                     }
                 >
@@ -175,6 +175,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilters: route.params.setFilters,
                             filterByContact,
                             setFilterByContact,
+                            setIsFilterSaved,
                         })
                     }
                 >
@@ -198,6 +199,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilters: route.params.setFilters,
                             filterByTag,
                             setFilterByTag,
+                            setIsFilterSaved,
                         })
                     }
                 >
@@ -219,30 +221,18 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                     </HStack>
                 </Pressable>
                 <Box marginTop="25px" />
-                {!(
-                    filterByTransaction === filtersByTransaction[0] &&
-                    filterByDate === filtersByDate[0] &&
-                    filterByContact.length === 0 &&
-                    filterByTag.length === 0
-                ) &&
-                    (!isFilterSaved ||
-                        !(
-                            filterByTransaction === route.params.filters[0] &&
-                            filterByDate === route.params.filters[1] &&
-                            filterByContact.length === 0 &&
-                            filterByTag.length === 0
-                        )) && (
-                        <SaveFilterActionSheet
-                            setIsUsingSavedFilter={route.params.setIsUsingSavedFilter}
-                            setIsFilterSaved={setIsFilterSaved}
-                            setFilters={route.params.setFilters}
-                            filterByTransaction={filterByTransaction}
-                            filterByDate={filterByDate}
-                            filterByContact={filterByContact}
-                            filterByTag={filterByTag}
-                            currencyType={route.params.wallet.currencyType}
-                        />
-                    )}
+                {/* If areFiltersDefault and isFilterSaved is false then display SaveFilterActionSheet*/}
+                {!areFiltersDefault() && !isFilterSaved && (
+                    <SaveFilterActionSheet
+                        setIsFilterSaved={setIsFilterSaved}
+                        setFilters={route.params.setFilters}
+                        filterByTransaction={filterByTransaction}
+                        filterByDate={filterByDate}
+                        filterByContact={filterByContact}
+                        filterByTag={filterByTag}
+                        currencyType={route.params.wallet.currencyType}
+                    />
+                )}
             </ScrollView>
             <Box style={styles.applyFiltersButtonContainer}>
                 <Button
@@ -268,7 +258,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         route.params.setIsUsingSavedFilter(false);
                         route.params.setContactFilters(filterByContact);
                         route.params.setTagFilters(filterByTag);
-                        setIsFilterSaved(false);
+                        route.params.setIsUsingSavedFilter(isFilterSaved);
                         navigation.goBack();
                     }}
                     testID="applyFiltersSubmit"

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -92,21 +92,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
         })();
     }, [filterByTransaction, filterByDate, isFilterSaved, filterByContact, filterByTag]);
 
-    function renderFilterByContact() {
-        let contacts = "";
-
-        // build a contact string with all the contacts separated by commas
-        for (let i = 0; i < filterByContact.length; i++) {
-            if (i === filterByContact.length - 1) {
-                contacts += filterByContact[i];
-            } else {
-                contacts += filterByContact[i] + ", ";
-            }
-        }
-
-        return contacts;
-    }
-
     return (
         <View style={styles.view}>
             <ScrollView style={styles.scrollView}>
@@ -188,7 +173,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         </Text>
                         <Box flex={1}>
                             <Text color={"text.500"} marginRight={"10px"} isTruncated style={{ marginLeft: "auto" }}>
-                                {renderFilterByContact()}
+                                {filterByContact.join(", ")}
                             </Text>
                         </Box>
                         <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -1,6 +1,6 @@
 import { View } from "../../components/Themed";
 import { StyleSheet } from "react-native";
-import { Text, Radio, Box, Button, HStack, Link, Pressable, ScrollView } from "native-base";
+import { Text, Box, Button, HStack, Link, Pressable, ScrollView, Badge, VStack } from "native-base";
 import { HomeStackScreenProps } from "../../types";
 import React from "react";
 import { getFiltersByDateStrings, getFiltersByTransactionStrings } from "../../services/filter_service";
@@ -25,12 +25,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
 
     const [filterByContact, setFilterByContact] = React.useState<string[]>([...route.params.contactFilters]);
     const [filterByTag, setFilterByTag] = React.useState<string[]>([...route.params.tagFilters]);
-
-    type RadioProps = {
-        value: string;
-        setValue: React.Dispatch<React.SetStateAction<string>>;
-        options: string[];
-    };
 
     const areFiltersDefault = () =>
         filterByTransaction === filtersByTransaction[0] &&
@@ -97,26 +91,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
         })();
     }, [filterByTransaction, filterByDate, isFilterSaved, filterByContact, filterByTag]);
 
-    function RadioGroup({ options, value, setValue }: RadioProps) {
-        return (
-            <Radio.Group
-                name="myRadioGroup"
-                value={value}
-                onChange={(nextValue) => {
-                    setValue(nextValue);
-                }}
-            >
-                {options.map((option) => (
-                    <Box style={styles.RadioItem} key={option}>
-                        <Radio key={option} value={option} color={"darkBlue.500"}>
-                            {option}
-                        </Radio>
-                    </Box>
-                ))}
-            </Radio.Group>
-        );
-    }
-
     function renderFilterByContact() {
         let contacts = "";
 
@@ -135,17 +109,45 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
     return (
         <View style={styles.view}>
             <ScrollView style={styles.scrollView}>
-                <Box marginTop="20px" />
-                <Text fontWeight={"semibold"} color={"text.500"}>
-                    Filter by transaction
-                </Text>
-                <RadioGroup
-                    options={filtersByTransaction}
-                    value={filterByTransaction}
-                    setValue={setFilterByTransaction}
-                />
+                <VStack alignItems="left" marginTop={"20px"} space={"10px"}>
+                    <Text color={"text.700"}>Transaction</Text>
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                        <HStack>
+                            {filtersByTransaction.map((option) => (
+                                <Pressable
+                                    key={option}
+                                    onPress={() => {
+                                        setFilterByTransaction(option);
+                                        setIsFilterSaved(false);
+                                    }}
+                                >
+                                    <Badge
+                                        borderRadius={"8px"}
+                                        backgroundColor="gray.100"
+                                        px={"10px"}
+                                        py={"5px"}
+                                        key={option}
+                                        style={[
+                                            styles.badge,
+                                            filterByTransaction === option
+                                                ? { borderColor: "#404040", borderWidth: 1 }
+                                                : {},
+                                        ]}
+                                    >
+                                        <Text
+                                            size={"subheadline"}
+                                            fontWeight={filterByTransaction === option ? "semibold" : "regular"}
+                                        >
+                                            {option}
+                                        </Text>
+                                    </Badge>
+                                </Pressable>
+                            ))}
+                        </HStack>
+                    </ScrollView>
+                </VStack>
                 <Pressable
-                    marginTop="25px"
+                    marginTop="15px"
                     onPress={() =>
                         navigation.navigate("FilterDateScreen", {
                             filters: route.params.filters,
@@ -255,7 +257,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         }
 
                         route.params.setFilters(filters);
-                        route.params.setIsUsingSavedFilter(false);
                         route.params.setContactFilters(filterByContact);
                         route.params.setTagFilters(filterByTag);
                         route.params.setIsUsingSavedFilter(isFilterSaved);
@@ -285,10 +286,7 @@ const styles = StyleSheet.create({
         marginLeft: "auto",
     },
     badge: {
-        paddingHorizontal: 15,
-        paddingVertical: 8,
-        marginRight: 13,
-        marginBottom: 13,
+        marginRight: 10,
         justifyContent: "center",
     },
     applyFiltersButtonContainer: {

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -216,7 +216,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             <VStack space={"10px"} style={{ width: "100%", overflow: "hidden" }}>
                                 <Text>Tags</Text>
                                 <HStack flexWrap={"wrap"}>
-                                    {SortService.sortAlphabetically(filterByTag).map((tag, i) => (
+                                    {SortService.sortAlphabetically(filterByTag).map((tag) => (
                                         <Badge
                                             borderRadius={"8px"}
                                             backgroundColor="gray.100"

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -23,7 +23,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
     );
     const [filterByDate, setFilterByDate] = React.useState(route.params.filters[1] || filtersByDate[0]);
 
-    const [filterByContact, setFilterByContact] = React.useState<string[]>([]);
+    const [filterByContact, setFilterByContact] = React.useState<string[]>([...route.params.contactFilters]);
     const [filterByTag, setFilterByTag] = React.useState<string[]>([]);
 
     type RadioProps = {
@@ -51,12 +51,10 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                 onPress={() => {
                     setFilterByTransaction(filtersByTransaction[0]);
                     setFilterByDate(filtersByDate[0]);
-                    route.params.setFilters([filtersByTransaction[0], filtersByDate[0]]);
                     route.params.setIsUsingSavedFilter(false);
-                    route.params.setContactFilters([]);
-                    route.params.setTagFilters([]);
                     setFilterByContact([]);
                     setFilterByTag([]);
+                    route.params.setTagFilters([]);
                     setIsFilterSaved(false);
                 }}
             >
@@ -64,10 +62,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
             </Link>
         );
     }
-
-    React.useEffect(() => {
-        setFilterByContact(route.params.contactFilters);
-    }, [route.params.contactFilters, isFocused]);
 
     React.useEffect(() => {
         setFilterByTag(route.params.tagFilters);
@@ -184,7 +178,8 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         navigation.navigate("FilterContactScreen", {
                             filters: route.params.filters,
                             setFilters: route.params.setFilters,
-                            contactFilters: route.params.contactFilters,
+                            filterByContact,
+                            setFilterByContact,
                             setContactFilters: route.params.setContactFilters,
                         })
                     }
@@ -249,6 +244,8 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilters={route.params.setFilters}
                             filterByTransaction={filterByTransaction}
                             filterByDate={filterByDate}
+                            filterByContact={filterByContact}
+                            filterByTag={filterByTag}
                             currencyType={route.params.wallet.currencyType}
                         />
                     )}
@@ -258,8 +255,8 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                     isDisabled={
                         filterByTransaction === route.params.filters[0] &&
                         filterByDate === route.params.filters[1] &&
-                        filterByContact.length === 0 &&
-                        filterByTag.length === 0
+                        JSON.stringify(filterByContact) === JSON.stringify(route.params.contactFilters) &&
+                        JSON.stringify(filterByTag) === JSON.stringify(route.params.tagFilters)
                     }
                     onPress={() => {
                         const filters = [filterByTransaction];
@@ -275,6 +272,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
 
                         route.params.setFilters(filters);
                         route.params.setIsUsingSavedFilter(false);
+                        route.params.setContactFilters(filterByContact);
                         setIsFilterSaved(false);
                         navigation.goBack();
                     }}

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -24,7 +24,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
     const [filterByDate, setFilterByDate] = React.useState(route.params.filters[1] || filtersByDate[0]);
 
     const [filterByContact, setFilterByContact] = React.useState<string[]>([...route.params.contactFilters]);
-    const [filterByTag, setFilterByTag] = React.useState<string[]>([]);
+    const [filterByTag, setFilterByTag] = React.useState<string[]>([...route.params.tagFilters]);
 
     type RadioProps = {
         value: string;
@@ -54,7 +54,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                     route.params.setIsUsingSavedFilter(false);
                     setFilterByContact([]);
                     setFilterByTag([]);
-                    route.params.setTagFilters([]);
                     setIsFilterSaved(false);
                 }}
             >
@@ -62,10 +61,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
             </Link>
         );
     }
-
-    React.useEffect(() => {
-        setFilterByTag(route.params.tagFilters);
-    }, [route.params.tagFilters, isFocused]);
 
     React.useEffect(() => {
         if (filterByDate === "Custom Dates") {
@@ -180,7 +175,6 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilters: route.params.setFilters,
                             filterByContact,
                             setFilterByContact,
-                            setContactFilters: route.params.setContactFilters,
                         })
                     }
                 >
@@ -202,8 +196,8 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         navigation.navigate("FilterTagScreen", {
                             filters: route.params.filters,
                             setFilters: route.params.setFilters,
-                            tagFilters: route.params.tagFilters,
-                            setTagFilters: route.params.setTagFilters,
+                            filterByTag,
+                            setFilterByTag,
                         })
                     }
                 >
@@ -273,6 +267,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         route.params.setFilters(filters);
                         route.params.setIsUsingSavedFilter(false);
                         route.params.setContactFilters(filterByContact);
+                        route.params.setTagFilters(filterByTag);
                         setIsFilterSaved(false);
                         navigation.goBack();
                     }}

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -10,6 +10,7 @@ import SaveFilterActionSheet from "../../components/SaveFilterActionSheet";
 import { fasBookmark } from "../../components/icons/solid/fasBookmark";
 import { farChevronRight } from "../../components/icons/regular/farChevronRight";
 import { useIsFocused } from "@react-navigation/native";
+import SortService from "../../services/sort_service";
 
 export default function FilterScreen({ route, navigation }: HomeStackScreenProps<"FilterScreen">) {
     const isFocused = useIsFocused();
@@ -110,7 +111,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
         <View style={styles.view}>
             <ScrollView style={styles.scrollView}>
                 <VStack alignItems="left" marginTop={"20px"} space={"10px"}>
-                    <Text color={"text.700"}>Transaction</Text>
+                    <Text>Transaction</Text>
                     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                         <HStack>
                             {filtersByTransaction.map((option) => (
@@ -205,24 +206,38 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                         })
                     }
                 >
-                    <HStack height="44px" alignItems="center">
-                        <Text color={"text.700"} marginRight="15">
-                            Tags
-                        </Text>
-                        <Box flex={1}></Box>
-                        {filterByTag.map((tag) => (
-                            <Pressable borderRadius={"8px"} backgroundColor="gray.100" style={styles.badge} key={tag}>
-                                <HStack space={"10px"} alignItems={"center"}>
-                                    <Text size={"subheadline"} fontWeight={"semibold"}>
-                                        {tag}
-                                    </Text>
+                    {filterByTag.length === 0 ? (
+                        <HStack height={"44px"} marginBottom={"13px"} alignItems="center">
+                            <Text>Tags</Text>
+                            <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />
+                        </HStack>
+                    ) : (
+                        <HStack>
+                            <VStack space={"10px"} style={{ width: "100%", overflow: "hidden" }}>
+                                <Text>Tags</Text>
+                                <HStack flexWrap={"wrap"}>
+                                    {SortService.sortAlphabetically(filterByTag).map((tag, i) => (
+                                        <Badge
+                                            borderRadius={"8px"}
+                                            backgroundColor="gray.100"
+                                            px={"10px"}
+                                            py={"5px"}
+                                            key={tag}
+                                            style={styles.badge}
+                                            marginBottom={"13px"}
+                                        >
+                                            <Text size={"subheadline"} fontWeight={"semibold"} isTruncated>
+                                                {tag}
+                                            </Text>
+                                        </Badge>
+                                    ))}
                                 </HStack>
-                            </Pressable>
-                        ))}
-                        <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />
-                    </HStack>
+                            </VStack>
+                            <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />
+                        </HStack>
+                    )}
                 </Pressable>
-                <Box marginTop="25px" />
+                <Box marginTop="12px" />
                 {/* If areFiltersDefault and isFilterSaved is false then display SaveFilterActionSheet*/}
                 {!areFiltersDefault() && !isFilterSaved && (
                     <SaveFilterActionSheet

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -74,6 +74,12 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
     }, [route.params.tagFilters, isFocused]);
 
     React.useEffect(() => {
+        if (filterByDate === "Custom Dates") {
+            setFilterByDate(filtersByDate[0]);
+        }
+    }, [filterByDate, isFocused]);
+
+    React.useEffect(() => {
         (() => {
             navigation.setOptions({
                 headerRight: () => (
@@ -132,11 +138,10 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                 contacts += filterByContact[i];
             } else {
                 contacts += filterByContact[i] + ", ";
-
             }
         }
 
-        return contacts ;
+        return contacts;
     }
 
     return (
@@ -189,7 +194,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             Contacts
                         </Text>
                         <Box flex={1}>
-                            <Text color={"text.500"} marginRight={"10px"} isTruncated style={{marginLeft: "auto"}}>
+                            <Text color={"text.500"} marginRight={"10px"} isTruncated style={{ marginLeft: "auto" }}>
                                 {renderFilterByContact()}
                             </Text>
                         </Box>

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -123,6 +123,22 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
         );
     }
 
+    function renderFilterByContact() {
+        let contacts = "";
+
+        // build a contact string with all the contacts separated by commas
+        for (let i = 0; i < filterByContact.length; i++) {
+            if (i === filterByContact.length - 1) {
+                contacts += filterByContact[i];
+            } else {
+                contacts += filterByContact[i] + ", ";
+
+            }
+        }
+
+        return contacts ;
+    }
+
     return (
         <View style={styles.view}>
             <ScrollView style={styles.scrollView}>
@@ -145,22 +161,20 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setFilterByDate,
                         })
                     }
-                    _pressed={{
-                        background: "text.200",
-                    }}
                 >
-                    <HStack height="50px" alignItems="center">
-                        <Text fontWeight={"semibold"} color={"text.500"} marginRight="15">
+                    <HStack height="44px" alignItems="center">
+                        <Text color={"text.700"} marginRight="15">
                             Date
                         </Text>
-                        <Text color={"text.500"} marginRight="1">
+                        <Box flex={1}></Box>
+                        <Text color={"text.500"} marginRight={"10px"}>
                             {filterByDate === filtersByDate[0] || filterByDate === "Custom Dates" ? "" : filterByDate}
                         </Text>
                         <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />
                     </HStack>
                 </Pressable>
                 <Pressable
-                    marginTop="25px"
+                    marginTop="15px"
                     onPress={() =>
                         navigation.navigate("FilterContactScreen", {
                             filters: route.params.filters,
@@ -169,24 +183,21 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setContactFilters: route.params.setContactFilters,
                         })
                     }
-                    _pressed={{
-                        background: "text.200",
-                    }}
                 >
-                    <HStack height="50px" alignItems="center">
-                        <Text fontWeight={"semibold"} color={"text.500"} marginRight="15">
+                    <HStack height="44px" alignItems="center">
+                        <Text color={"text.700"} marginRight="15">
                             Contacts
                         </Text>
-                        {filterByContact.map((contact) => (
-                            <Text color={"text.500"} marginRight="1" key={contact}>
-                                {contact},
+                        <Box flex={1}>
+                            <Text color={"text.500"} marginRight={"10px"} isTruncated style={{marginLeft: "auto"}}>
+                                {renderFilterByContact()}
                             </Text>
-                        ))}
+                        </Box>
                         <FontAwesomeIcon icon={farChevronRight} style={styles.chevronRightIcon} size={16} />
                     </HStack>
                 </Pressable>
                 <Pressable
-                    marginTop="25px"
+                    marginTop="15px"
                     onPress={() =>
                         navigation.navigate("FilterTagScreen", {
                             filters: route.params.filters,
@@ -195,14 +206,12 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             setTagFilters: route.params.setTagFilters,
                         })
                     }
-                    _pressed={{
-                        background: "text.200",
-                    }}
                 >
-                    <HStack height="50px" alignItems="center">
-                        <Text fontWeight={"semibold"} color={"text.500"} marginRight="15">
+                    <HStack height="44px" alignItems="center">
+                        <Text color={"text.700"} marginRight="15">
                             Tags
                         </Text>
+                        <Box flex={1}></Box>
                         {filterByTag.map((tag) => (
                             <Pressable borderRadius={"8px"} backgroundColor="gray.100" style={styles.badge} key={tag}>
                                 <HStack space={"10px"} alignItems={"center"}>
@@ -238,9 +247,9 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                             currencyType={route.params.wallet.currencyType}
                         />
                     )}
-                <Box marginTop="25px" />
+            </ScrollView>
+            <Box style={styles.applyFiltersButtonContainer}>
                 <Button
-                    style={styles.applyButton}
                     isDisabled={
                         filterByTransaction === route.params.filters[0] &&
                         filterByDate === route.params.filters[1] &&
@@ -268,7 +277,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
                 >
                     Apply filters
                 </Button>
-            </ScrollView>
+            </Box>
         </View>
     );
 }
@@ -283,14 +292,9 @@ const styles = StyleSheet.create({
     RadioItem: {
         marginTop: 20,
     },
-    applyButton: {
-        marginTop: "auto",
-        marginBottom: 15,
-    },
     chevronRightIcon: {
         color: "#A3A3A3",
         marginLeft: "auto",
-        marginRight: 5,
     },
     badge: {
         paddingHorizontal: 15,
@@ -298,5 +302,15 @@ const styles = StyleSheet.create({
         marginRight: 13,
         marginBottom: 13,
         justifyContent: "center",
+    },
+    applyFiltersButtonContainer: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        paddingHorizontal: 15,
+        paddingBottom: 15,
+        paddingTop: 8,
+        backgroundColor: "white",
     },
 });

--- a/packages/client/screens/filters/FilterScreen.tsx
+++ b/packages/client/screens/filters/FilterScreen.tsx
@@ -110,7 +110,7 @@ export default function FilterScreen({ route, navigation }: HomeStackScreenProps
     return (
         <View style={styles.view}>
             <ScrollView style={styles.scrollView}>
-                <VStack alignItems="left" marginTop={"20px"} space={"10px"}>
+                <VStack marginTop={"20px"} space={"10px"}>
                     <Text>Transaction</Text>
                     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                         <HStack>

--- a/packages/client/screens/filters/FilterTagScreen.tsx
+++ b/packages/client/screens/filters/FilterTagScreen.tsx
@@ -34,6 +34,7 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
         setTransactionTagsNotAdded([...transactionTagsNotAdded, tag]);
         route.params.filterByTag.splice(route.params.filterByTag.indexOf(tag.tagName), 1);
         route.params.setFilterByTag(route.params.filterByTag);
+        route.params.setIsFilterSaved(false);
     }
 
     function addTransactionTag(tag: Tag) {
@@ -41,6 +42,7 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
         setTransactionTags([...transactionTags, tag]);
         route.params.filterByTag.push(tag.tagName);
         route.params.setFilterByTag([...route.params.filterByTag]);
+        route.params.setIsFilterSaved(false);
     }
 
     React.useEffect(() => {
@@ -54,6 +56,7 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
                                 route.params.setFilterByTag([]);
                                 setTransactionTagsNotAdded([...transactionTagsNotAdded, ...transactionTags]);
                                 setTransactionTags([]);
+                                route.params.setIsFilterSaved(false);
                             }}
                         >
                             <Text color={"#007AFF"} fontWeight={"semibold"}>

--- a/packages/client/screens/filters/FilterTagScreen.tsx
+++ b/packages/client/screens/filters/FilterTagScreen.tsx
@@ -24,23 +24,23 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
     React.useEffect(() => {
         (async () => {
             const tags = await tagsGateway.findAllTags({ id: user.id }, token);
-            setTransactionTags(tags.filter((tag) => route.params.tagFilters.includes(tag.tagName)));
-            setTransactionTagsNotAdded(tags.filter((tag) => !route.params.tagFilters.includes(tag.tagName)));
+            setTransactionTags(tags.filter((tag) => route.params.filterByTag.includes(tag.tagName)));
+            setTransactionTagsNotAdded(tags.filter((tag) => !route.params.filterByTag.includes(tag.tagName)));
         })();
     }, []);
 
     function removeTransactionTag(tag: Tag) {
         setTransactionTags(transactionTags.filter((t) => t !== tag));
         setTransactionTagsNotAdded([...transactionTagsNotAdded, tag]);
-        route.params.tagFilters.splice(route.params.tagFilters.indexOf(tag.tagName), 1);
-        route.params.setTagFilters(route.params.tagFilters);
+        route.params.filterByTag.splice(route.params.filterByTag.indexOf(tag.tagName), 1);
+        route.params.setFilterByTag(route.params.filterByTag);
     }
 
     function addTransactionTag(tag: Tag) {
         setTransactionTagsNotAdded(transactionTagsNotAdded.filter((t) => t !== tag));
         setTransactionTags([...transactionTags, tag]);
-        route.params.tagFilters.push(tag.tagName);
-        route.params.setTagFilters([...route.params.tagFilters]);
+        route.params.filterByTag.push(tag.tagName);
+        route.params.setFilterByTag([...route.params.filterByTag]);
     }
 
     React.useEffect(() => {
@@ -50,8 +50,8 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
                     transactionTags.length > 0 && (
                         <Pressable
                             onPress={() => {
-                                route.params.tagFilters.splice(0);
-                                route.params.setTagFilters([]);
+                                route.params.filterByTag.splice(0);
+                                route.params.setFilterByTag([]);
                                 setTransactionTagsNotAdded([...transactionTagsNotAdded, ...transactionTags]);
                                 setTransactionTags([]);
                             }}

--- a/packages/client/screens/filters/FilterTagScreen.tsx
+++ b/packages/client/screens/filters/FilterTagScreen.tsx
@@ -80,7 +80,7 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
                     <VStack space={"40px"}>
                         {transactionTags.length != 0 && (
                             <TagsGallery
-                                title={"Selected Transaction"}
+                                title={"Selected Tags"}
                                 tags={SortService.sortTransactionTagsAlphabetically(transactionTags)}
                                 onTagPress={(tag) => removeTransactionTag(tag)}
                                 tagIcon={farXMark}
@@ -91,8 +91,10 @@ export default function FilterTagScreen({ route, navigation }: HomeStackScreenPr
                             <TagsGallery
                                 title={"All Tags"}
                                 tags={SortService.sortTransactionTagsAlphabetically(transactionTagsNotAdded)}
-                                onTagPress={(tag: Tag) => addTransactionTag(tag)}
-                                tagIcon={farPlus}
+                                onTagPress={(tag: Tag) => {
+                                    if (transactionTags.length < 10) addTransactionTag(tag);
+                                }}
+                                tagIcon={transactionTags.length < 10 ? farPlus : undefined}
                                 styles={styles.allTags}
                                 tagTestIDPrefix={"allTags"}
                             />

--- a/packages/client/screens/filters/SavedFiltersScreen.tsx
+++ b/packages/client/screens/filters/SavedFiltersScreen.tsx
@@ -4,14 +4,14 @@ import { Text, Box, Center, Pressable, HStack } from "native-base";
 import { HomeStackScreenProps } from "../../types";
 import React from "react";
 import { getFiltersByTransactionStrings } from "../../services/filter_service";
-import { farBookmark } from "../../components/icons/regular/farBookmark";
+import { falBookmark } from "../../components/icons/light/falBookmark";
 import { FontAwesomeIcon } from "@fortawesome/react-native-fontawesome";
 import { useIsFocused } from "@react-navigation/native";
 import { AuthContext } from "../../components/contexts/AuthContext";
 import { FiltersGateway } from "../../gateways/filters_gateway";
 import { Filter } from "@cryptify/common/src/domain/entities/filter";
-import { titleCase } from "@cryptify/common/src/utils/string_utils";
 import { SwipeListView } from "react-native-swipe-list-view";
+import { getCurrencyTypeUILabel } from "@cryptify/common/src/utils/currency_utils";
 
 export default function SavedFiltersScreen({ route, navigation }: HomeStackScreenProps<"SavedFiltersScreen">) {
     const filtersGateway = new FiltersGateway();
@@ -71,11 +71,11 @@ export default function SavedFiltersScreen({ route, navigation }: HomeStackScree
 
         filters[1] = filter.range;
 
-        route.params.setFilters(filters);
         route.params.setFilterByTransaction(filters[0]);
         route.params.setFilterByDate(filters[1]);
+        route.params.setFilterByContact(filter.contactNames);
+        route.params.setFilterByTag(filter.tagNames);
         route.params.setIsFilterSaved(true);
-        route.params.setIsUsingSavedFilter(true);
         navigation.goBack();
     }
 
@@ -153,9 +153,10 @@ export default function SavedFiltersScreen({ route, navigation }: HomeStackScree
             {filtersWithHeader.length === 0 ? (
                 <Center alignItems="center" marginY="auto">
                     <Box marginTop="-10px"></Box>
-                    <FontAwesomeIcon icon={farBookmark} style={styles.emptyIcon} size={56} color={"#404040"} />
+                    <FontAwesomeIcon icon={falBookmark} style={styles.emptyIcon} size={56} color={"#404040"} />
                     <Text style={styles.emptyText}>
-                        You do not have any saved filters{"\n"}for {titleCase(route.params.currencyType)} wallets.
+                        You do not have any saved filters for {getCurrencyTypeUILabel(route.params.currencyType)}{" "}
+                        wallets.
                     </Text>
                 </Center>
             ) : (

--- a/packages/client/services/sort_service.ts
+++ b/packages/client/services/sort_service.ts
@@ -78,6 +78,10 @@ function sortTransactionTagsAlphabetically(transactionTags: Tag[]): Tag[] {
     return transactionTags.sort((a, b) => (a.tagName > b.tagName ? 1 : -1));
 }
 
+function sortAlphabetically(array: string[]): string[] {
+    return array.sort((a, b) => (a > b ? 1 : -1));
+}
+
 export default {
     sortDateNewest,
     sortDateOldest,
@@ -86,4 +90,5 @@ export default {
     sortTransactions,
     sortBadgeValues,
     sortTransactionTagsAlphabetically,
+    sortAlphabetically,
 };

--- a/packages/client/tests/system/CRYP-32_saved_filters.e2e.ts
+++ b/packages/client/tests/system/CRYP-32_saved_filters.e2e.ts
@@ -28,11 +28,11 @@ describe("CRYP-32 Saved filters", () => {
         await element(by.text("Save this filter")).tap();
 
         await element(by.id("addFilterInput")).typeText("My Filter");
-        await element(by.text("Save filter")).tap();
+        await element(by.text("Save Filter")).tap();
         await element(by.text("Save filter")).tap();
 
         // Assert correct filter label
-        await expect(element(by.text("Filter saved"))).toBeVisible();
+        await expect(element(by.text("Filter"))).toBeVisible();
         await expect(element(by.text("Ethereum in"))).toBeVisible();
     });
 });

--- a/packages/client/tests/system/CRYP-32_saved_filters.e2e.ts
+++ b/packages/client/tests/system/CRYP-32_saved_filters.e2e.ts
@@ -32,7 +32,7 @@ describe("CRYP-32 Saved filters", () => {
         await element(by.text("Save filter")).tap();
 
         // Assert correct filter label
-        await expect(element(by.text("Filter"))).toBeVisible();
+        await expect(element(by.text("Filter saved"))).toBeVisible();
         await expect(element(by.text("Ethereum in"))).toBeVisible();
     });
 });

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -97,6 +97,7 @@ type FilterContactScreenProps = {
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     filterByContact: string[];
     setFilterByContact: React.Dispatch<React.SetStateAction<string[]>>;
+    setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type FilterTagScreenProps = {
@@ -104,6 +105,7 @@ type FilterTagScreenProps = {
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     filterByTag: string[];
     setFilterByTag: React.Dispatch<React.SetStateAction<string[]>>;
+    setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type FilterDateScreenProps = {
@@ -111,14 +113,15 @@ type FilterDateScreenProps = {
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     filterByDate: string;
     setFilterByDate: React.Dispatch<React.SetStateAction<string>>;
+    setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 type SavedFiltersScreenProps = {
     currencyType: CurrencyType;
-    setFilters: React.Dispatch<React.SetStateAction<string[]>>;
     setFilterByTransaction: React.Dispatch<React.SetStateAction<string>>;
     setFilterByDate: React.Dispatch<React.SetStateAction<string>>;
-    setIsUsingSavedFilter: React.Dispatch<React.SetStateAction<boolean>>;
+    setFilterByContact: React.Dispatch<React.SetStateAction<string[]>>;
+    setFilterByTag: React.Dispatch<React.SetStateAction<string[]>>;
     setIsFilterSaved: React.Dispatch<React.SetStateAction<boolean>>;
 };
 

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -95,15 +95,15 @@ type FilterScreenProps = {
 type FilterContactScreenProps = {
     filters: string[];
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
-    contactFilters: string[];
-    setContactFilters: React.Dispatch<React.SetStateAction<string[]>>;
+    filterByContact: string[];
+    setFilterByContact: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 type FilterTagScreenProps = {
     filters: string[];
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
-    tagFilters: string[];
-    setTagFilters: React.Dispatch<React.SetStateAction<string[]>>;
+    filterByTag: string[];
+    setFilterByTag: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 type FilterDateScreenProps = {

--- a/packages/client/types.tsx
+++ b/packages/client/types.tsx
@@ -106,6 +106,13 @@ type FilterTagScreenProps = {
     setTagFilters: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
+type FilterDateScreenProps = {
+    filters: string[];
+    setFilters: React.Dispatch<React.SetStateAction<string[]>>;
+    filterByDate: string;
+    setFilterByDate: React.Dispatch<React.SetStateAction<string>>;
+};
+
 type SavedFiltersScreenProps = {
     currencyType: CurrencyType;
     setFilters: React.Dispatch<React.SetStateAction<string[]>>;
@@ -166,6 +173,7 @@ export type HomeStackParamList = {
     FilterScreen: FilterScreenProps;
     FilterContactScreen: FilterContactScreenProps;
     FilterTagScreen: FilterTagScreenProps;
+    FilterDateScreen: FilterDateScreenProps;
     SavedFiltersScreen: SavedFiltersScreenProps;
     TransactionTagsScreen: TransactionTagsScreenProps;
     AddTransactionTagsScreen: AddTransactionTagsScreenProps;


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-352

## Fix

- Refactored `Filter by Transaction` to match UI mockups
- Moved `Filter by Date` to a separate screen
- Fixed saved filters not storing contacts and tags in the database
- Fixed the `Reset` button in the filter screen not properly resetting all filters across screens
- Fixed filter states not properly persisting between transaction list and filter screen(s)
- Updated tag filter badges in transaction list to match UI mockups
- Fix `Save this filter` not properly displaying/hiding 
- Refactor tag badge order to match specs
- Refactoring spacing/styling to match UI mockups
- Fixed all associated system tests

![337008825_5525204817581441_6127166996984588362_n](https://user-images.githubusercontent.com/15861967/229201755-56c5ccf3-c786-4afa-b6ca-18ba9eb59722.jpg)
![337146897_618328433003381_3662064867418442761_n](https://user-images.githubusercontent.com/15861967/229201758-add72e73-0082-4d13-b151-e9ef28b78a80.jpg)
![337106307_1289887598324883_6885027930020036483_n](https://user-images.githubusercontent.com/15861967/229201761-8c462e4b-8b81-42d2-85b0-006ca975ac39.jpg)
![337298563_1211131732713176_5488726456627263067_n](https://user-images.githubusercontent.com/15861967/229201763-58d7d33d-be41-4674-9e7f-d2b029758008.jpg)
![337037127_231712736186305_6752166480453125614_n](https://user-images.githubusercontent.com/15861967/229201765-573ccf89-62a7-4f99-8303-3a6ab1463a0f.jpg)
![334687952_180184301482257_7535258643205648768_n](https://user-images.githubusercontent.com/15861967/229201766-a19571c8-056e-4652-8c54-9d3f539e4c87.jpg)
![337172777_2184726268390259_2390752876109899885_n](https://user-images.githubusercontent.com/15861967/229201767-38f03d6e-f57d-4dfe-bae5-be720db760c8.jpg)
