### PR TITLE
CRYP-271: Remove ungranted QR code camera permissions system tests

### DIFF
--- a/packages/client/tests/system/CRYP-269_add_bitcoin_wallet_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-269_add_bitcoin_wallet_by_qr_code.e2e.ts
@@ -11,9 +11,19 @@ import {
 } from "./utils/test_utils";
 
 describe("CRYP-269 Add Bitcoin wallet by QR code", () => {
-    // Dev Note: For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
+    // Dev Note:
+    // For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
     // This also means we cannot test the toast message that displays after scanning an incorrect QR code. This functionality could not
     // be successfully mocked either. As a result, whenever the QRCodeScannerScreen is displayed we are only asserting/testing that it is opened and closed.
+    //
+    // Additionally, currently it is not possible to properly test ungranted camera permissions for the following reasons:
+    // 1. Detox does not support ungranted camera permissions for Android emulators. Instead, camera permissions for Android emulator are always granted by default and there is no way to change them.
+    //      See the following links for more information:
+    //          - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
+    //          - https://github.com/wix/Detox/issues/477
+    // 2. No one in the team has a functioning iOS emulator to test this functionality on.
+    // Therefore, unfortunately, this test is not created at this time and will be skipped since it is not possible to properly test it,
+    // and all the following tests assume that the camera permissions are granted.
 
     it("Should be able to open the QR code scanner to add a Bitcoin wallet by scanning its QR code", async () => {
         await launchApp({
@@ -35,36 +45,6 @@ describe("CRYP-269 Add Bitcoin wallet by QR code", () => {
         await closeQRCodeScannerScreen();
 
         await expect(element(by.text("Add a Bitcoin Wallet"))).toBeVisible();
-
-        await displaySettingsFromAddBitcoinWallet();
-        await signOut();
-
-        await pause();
-    });
-
-    // Dev Note: This test, when run on Android, will always pass because Detox only supports permission's for iOS emulators.
-    // As a result, all permissions are granted by default for Android emulators and cannot be changed.
-    //
-    // See the following links for more information:
-    // - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
-    // - https://github.com/wix/Detox/issues/477
-    it("Should not be able to open the QR code scanner with ungranted camera permissions (iOS only)", async () => {
-        if (device.getPlatform() === "android") {
-            return;
-        }
-
-        await launchApp({
-            newInstance: true,
-            permissions: {
-                camera: "NO",
-            },
-        });
-
-        await signIn();
-        await addBitcoinWalletButton();
-        await openQRCodeScannerScreen();
-
-        // TODO: Assert camera permissions not granted alert displays
 
         await displaySettingsFromAddBitcoinWallet();
         await signOut();

--- a/packages/client/tests/system/CRYP-269_add_bitcoin_wallet_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-269_add_bitcoin_wallet_by_qr_code.e2e.ts
@@ -1,4 +1,4 @@
-import { by, device, expect, element } from "detox";
+import { by, expect, element } from "detox";
 import {
     assertQRCodeScannerScreenIsOpen,
     closeQRCodeScannerScreen,

--- a/packages/client/tests/system/CRYP-270_add_ethereum_wallet_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-270_add_ethereum_wallet_by_qr_code.e2e.ts
@@ -11,9 +11,19 @@ import {
 } from "./utils/test_utils";
 
 describe("CRYP-270 Add an Ethereum wallet by QR code", () => {
-    // Dev Note: For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
+    // Dev Note:
+    // For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
     // This also means we cannot test the toast message that displays after scanning an incorrect QR code. This functionality could not
     // be successfully mocked either. As a result, whenever the QRCodeScannerScreen is displayed we are only asserting/testing that it is opened and closed.
+    //
+    // Additionally, currently it is not possible to properly test ungranted camera permissions for the following reasons:
+    // 1. Detox does not support ungranted camera permissions for Android emulators. Instead, camera permissions for Android emulator are always granted by default and there is no way to change them.
+    //      See the following links for more information:
+    //          - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
+    //          - https://github.com/wix/Detox/issues/477
+    // 2. No one in the team has a functioning iOS emulator to test this functionality on.
+    // Therefore, unfortunately, this test is not created at this time and will be skipped since it is not possible to properly test it,
+    // and all the following tests assume that the camera permissions are granted.
 
     it("Should be able to open the QR code scanner to add an Ethereum wallet by scanning its QR code", async () => {
         await launchApp({
@@ -35,36 +45,6 @@ describe("CRYP-270 Add an Ethereum wallet by QR code", () => {
         await closeQRCodeScannerScreen();
 
         await expect(element(by.text("Add an Ethereum Wallet"))).toBeVisible();
-
-        await displaySettingsFromAddEthereumWallet();
-        await signOut();
-
-        await pause();
-    });
-
-    // Dev Note: This test, when run on Android, will always pass because Detox only supports permission's for iOS emulators.
-    // As a result, all permissions are granted by default for Android emulators and cannot be changed.
-    //
-    // See the following links for more information:
-    // - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
-    // - https://github.com/wix/Detox/issues/477
-    it("Should not be able to open the QR code scanner with ungranted camera permissions (iOS only)", async () => {
-        if (device.getPlatform() === "android") {
-            return;
-        }
-
-        await launchApp({
-            newInstance: true,
-            permissions: {
-                camera: "NO",
-            },
-        });
-
-        await signIn();
-        await addEthereumWalletButton();
-        await openQRCodeScannerScreen();
-
-        // TODO: Assert camera permissions not granted alert displays
 
         await displaySettingsFromAddEthereumWallet();
         await signOut();

--- a/packages/client/tests/system/CRYP-270_add_ethereum_wallet_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-270_add_ethereum_wallet_by_qr_code.e2e.ts
@@ -1,4 +1,4 @@
-import { by, device, expect, element } from "detox";
+import { by, expect, element } from "detox";
 import {
     assertQRCodeScannerScreenIsOpen,
     closeQRCodeScannerScreen,

--- a/packages/client/tests/system/CRYP-271_add_contact_wallets_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-271_add_contact_wallets_by_qr_code.e2e.ts
@@ -1,4 +1,4 @@
-import { by, device, expect, element } from "detox";
+import { by, expect, element } from "detox";
 import {
     assertQRCodeScannerScreenIsOpen,
     closeKeyboard,

--- a/packages/client/tests/system/CRYP-271_add_contact_wallets_by_qr_code.e2e.ts
+++ b/packages/client/tests/system/CRYP-271_add_contact_wallets_by_qr_code.e2e.ts
@@ -13,9 +13,19 @@ import {
 import { addContact, displayContactsScreen, editContact } from "./utils/test_contact_utils";
 
 describe("CRYP-271 Add a contact's wallet by scanning a QR code", () => {
-    // Dev Note: For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
+    // Dev Note:
+    // For all the following tests, scanning a QR code cannot be tested because the emulator's camera is not able to scan it.
     // This also means we cannot test the toast message that displays after scanning an incorrect QR code. This functionality could not
     // be successfully mocked either. As a result, whenever the QRCodeScannerScreen is displayed we are only asserting/testing that it is opened and closed.
+    //
+    // Additionally, currently it is not possible to properly test ungranted camera permissions for the following reasons:
+    // 1. Detox does not support ungranted camera permissions for Android emulators. Instead, camera permissions for Android emulator are always granted by default and there is no way to change them.
+    //      See the following links for more information:
+    //          - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
+    //          - https://github.com/wix/Detox/issues/477
+    // 2. No one in the team has a functioning iOS emulator to test this functionality on.
+    // Therefore, unfortunately, this test is not created at this time and will be skipped since it is not possible to properly test it,
+    // and all the following tests assume that the camera permissions are granted.
 
     it("Should be able to open the QR code scanner to add a Bitcoin wallet by scanning its QR code to a new contact", async () => {
         await launchApp({
@@ -136,47 +146,6 @@ describe("CRYP-271 Add a contact's wallet by scanning a QR code", () => {
         await expect(element(by.id("contactNameInput"))).toHaveText("Jason");
 
         await displaySettingsFromEditContact();
-        await signOut();
-
-        await pause();
-    });
-
-    // Dev Note: This test, when run on Android, will always pass because Detox only supports permission's for iOS emulators.
-    // As a result, all permissions are granted by default for Android emulators and cannot be changed.
-    //
-    // See the following links for more information:
-    // - https://wix.github.io/Detox/docs/next/api/device/#2-permissionsset-runtime-permissions-ios-only
-    // - https://github.com/wix/Detox/issues/477
-    it("Should not be able to open the QR code scanner with ungranted camera permissions (iOS only)", async () => {
-        if (device.getPlatform() === "android") {
-            return;
-        }
-
-        await launchApp({
-            newInstance: true,
-            permissions: {
-                camera: "NO",
-            },
-        });
-
-        await signIn();
-        await displayContactsScreen();
-
-        // Asserting the following code with the Add a Contact screen is equivalent to the
-        // Edit a Contact because both screens use the same components.
-        await addContact();
-        await closeKeyboard("contactNameInput");
-
-        // Expand the Bitcoin wallet section and add an input form field for a Bitcoin wallet
-        await element(by.id("walletCollapsibleButtonBITCOIN")).tap();
-        await element(by.id("addAnotherBITCOIN")).tap();
-        await expect(element(by.id("walletAddressInputBITCOIN"))).toBeVisible();
-
-        await openQRCodeScannerScreen();
-
-        // TODO: Assert camera permissions not granted alert displays
-
-        await displaySettingsFromAddContact();
         await signOut();
 
         await pause();


### PR DESCRIPTION
JIRA: https://cryptify.atlassian.net/browse/CRYP-271

## Changes

- All QR code ungranted camera permissions have been removed as outlined in the added comments to each system test file.
   - In short, these tests cannot be executed due to the limitation of Detox in relation to Android emulators (camera permissions are always granted and cannot be changed) and our current inability to run such tests on an iOS emulator. Therefore, having a test that is always guaranteed to pass based on the old code would be useless.